### PR TITLE
Add a looping 2mb put to prove eviction

### DIFF
--- a/distributed-map/eviction/src/main/java/Main.java
+++ b/distributed-map/eviction/src/main/java/Main.java
@@ -1,7 +1,23 @@
 import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+
+import java.util.Map;
 
 public class Main {
     public static void main(String[] args) {
-        Hazelcast.newHazelcastInstance();
+
+        HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance();
+        Map<Integer,String> personsMap = hazelcastInstance.getMap("persons");
+        String person = new String(new char[1000000]); // 2 MB
+        Runtime runtime = Runtime.getRuntime();
+
+        int keyCount=0;
+        int mb = 1024*1024;
+
+        while(true){
+            personsMap.put(keyCount,person);
+            keyCount ++;
+            System.out.printf("Unique Puts = %s keyCount : Free Memory (MB) = %s\n",keyCount,runtime.freeMemory()/mb);
+        }
     }
 }


### PR DESCRIPTION
This eviction example isn't currently in the book.

Previously the main class just started a hazelcast instance.  I've now added some code that loops and adds 2mb map entries to prove the JVM doesn't OOM.  I've added it for my Hazelcast Training Class.
