### PR TITLE
Changed hazelcast-all to hazelcast-hibernate4

### DIFF
--- a/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
@@ -24,8 +24,8 @@
 
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
-            <version>${hazelcast.version}</version>
+            <artifactId>hazelcast-hibernate4</artifactId>
+            <version>3.4-EA</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
If we use hazelcast-all, it wont work with hibernate4 and we will get a ClassNotFoundExpection, since, hazelcast-all includes hazelcast-hibernate3 instead of hazelcast-hibernate4.