### PR TITLE
Fixes in HD memory examples after code review

### DIFF
--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
@@ -38,17 +38,4 @@
         <allow-unsafe>true</allow-unsafe>
     </serialization>
 
-    <native-memory allocator-type="POOLED" enabled="false">
-        <size unit="GIGABYTES" value="1" />
-    </native-memory>
-
-    <!-- <near-cache name="default">
-        <max-size>50000</max-size>
-        <time-to-live-seconds>900</time-to-live-seconds>
-        <eviction-policy>LRU</eviction-policy>
-        <invalidate-on-change>true</invalidate-on-change>
-        <in-memory-format>OFFHEAP</in-memory-format>
-        <local-update-policy>INVALIDATE</local-update-policy>
-    </near-cache> -->
-
 </hazelcast-client>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/java/MemoryStatsUtil.java
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/java/MemoryStatsUtil.java
@@ -1,8 +1,11 @@
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceImpl;
 import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.instance.Node;
 import com.hazelcast.memory.DefaultMemoryStats;
+import com.hazelcast.memory.MemoryManager;
 import com.hazelcast.memory.MemoryStats;
+import com.hazelcast.nio.serialization.EnterpriseSerializationService;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.lang.reflect.Method;
@@ -10,17 +13,35 @@ import java.lang.reflect.Method;
 public class MemoryStatsUtil {
 
     public static MemoryStats getMemoryStats(HazelcastInstance hz) {
-        try {
-            if (hz instanceof HazelcastInstanceProxy) {
-                Method original = HazelcastInstanceProxy.class.getDeclaredMethod("getOriginal");
+        Node node = getNode(hz); // or another way for getting "Node" over "HazelcastInstance"
+        if (node != null) {
+            EnterpriseSerializationService serializationService =
+                (EnterpriseSerializationService) node.getSerializationService();
+            MemoryManager memoryManager = serializationService.getMemoryManager();
+            return memoryManager.getMemoryStats();
+        } else
+            return new DefaultMemoryStats();
+    }
+
+    public static Node getNode(HazelcastInstance hz) {
+        HazelcastInstanceImpl impl = getHazelcastInstanceImpl(hz);
+        return impl != null ? impl.node : null;
+    }
+
+    public static HazelcastInstanceImpl getHazelcastInstanceImpl(HazelcastInstance hz) {
+        HazelcastInstanceImpl impl = null;
+        if (hz instanceof HazelcastInstanceProxy) {
+            Method original = null;
+            try {
+                original = HazelcastInstanceProxy.class.getDeclaredMethod("getOriginal");
                 original.setAccessible(true);
-                return ((HazelcastInstanceImpl) original.invoke(hz)).getMemoryStats();
-            } else if (hz instanceof HazelcastInstanceImpl) {
-                return ((HazelcastInstanceImpl) hz).getMemoryStats();
+                impl = ((HazelcastInstanceImpl) original.invoke(hz));
+            } catch (Exception e) {
+                return ExceptionUtil.sneakyThrow(e);
             }
-        } catch (Exception e) {
-            return ExceptionUtil.sneakyThrow(e);
+        } else if (hz instanceof HazelcastInstanceImpl) {
+            impl = (HazelcastInstanceImpl) hz;
         }
-        return new DefaultMemoryStats();
+        return impl;
     }
 }


### PR DESCRIPTION
As per discussion and review with @serkan-ozal, made couple fixes in previously merged PR:
- removed HD near cache config
- used `EnterpriseSerializationService` to access native memory stats