### PR TITLE
missing dependency sun.jdk added sample jca project

### DIFF
--- a/hazelcast-integration/jca-ra/resources/jboss/module.xml
+++ b/hazelcast-integration/jca-ra/resources/jboss/module.xml
@@ -11,6 +11,7 @@
     </resources>
 
     <dependencies>
+            <module name="sun.jdk" />
 	        <module name="javax.api"/>
 			<module name="javax.resource.api"/>
 	        <module name="javax.transaction.api"/>


### PR DESCRIPTION
This was corrected in documentation but sample project was not corrected.