### PR TITLE
XML fixed so that cache returns same object

### DIFF
--- a/distributed-map/near-cache/src/main/resources/hazelcast.xml
+++ b/distributed-map/near-cache/src/main/resources/hazelcast.xml
@@ -9,6 +9,8 @@
             <time-to-live-seconds>60</time-to-live-seconds>
             <eviction-policy>NONE</eviction-policy>
             <invalidate-on-change>false</invalidate-on-change>
+            <in-memory-format>OBJECT</in-memory-format>
+            <cache-local-entries>true</cache-local-entries>
         </near-cache>
     </map>
 </hazelcast>


### PR DESCRIPTION
In order to get same object reference with second get operation, we need to specify `in memory format` as `OBJECT` and for caching to work in a single node we need to enable the `cache local entries` option.