### PR TITLE
Fixed Runtime Exception in Main class by correcting package name

### DIFF
--- a/jcache/src/main/java/com/hazelcast/examples/application/Main.java
+++ b/jcache/src/main/java/com/hazelcast/examples/application/Main.java
@@ -108,7 +108,7 @@ public class Main {
     private static Cache<Integer, User> configureCache(UserDao userDao) {
         // Explicitly retrieve the Hazelcast backed javax.cache.spi.CachingProvider
         CachingProvider cachingProvider = Caching.getCachingProvider(
-                "com.hazelcast.cache.impl.HazelcastCachingProvider"
+                "com.hazelcast.cache.HazelcastCachingProvider"
         );
 
         // Retrieve the javax.cache.CacheManager


### PR DESCRIPTION
In the Main class the *configureCache(...)* method throws a RuntimeException when making the call -

*Caching.getCachingProvider("com.hazelcast.cache.__impl__.HazelcastCachingProvider")*

Removing 'impl' from the package name fixes the issue. 