### PR TITLE
fixing build error

### DIFF
--- a/hazelcast-integration/mongodb/pom.xml
+++ b/hazelcast-integration/mongodb/pom.xml
@@ -29,7 +29,7 @@
     <groupId>com.hazelcast.mongodb</groupId>
     <artifactId>mongodb-integration</artifactId>
     <name>hazelcast-mongodb-integration-sample</name>
-    <packaging>war</packaging>
+    <packaging>jar</packaging>
     <properties>
         <java-version>1.6</java-version>
         <mongo-java-driver.version>3.0.4</mongo-java-driver.version>


### PR DESCRIPTION
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-war-plugin:2.2:war (default-war) on project mongodb-integration: Error assembling WAR: webxml attribute is required (or pre-existing WEB-INF/web.xml if executing in update mode) -> [Help 1]
```

@mesutcelik, please, review