### PR TITLE
Initial solution for auto-detecting nodes on AWS Elasticbeanstalk

### DIFF
--- a/hazelcast-integration/amazon-elasticbeanstalk/README.md
+++ b/hazelcast-integration/amazon-elasticbeanstalk/README.md
@@ -26,32 +26,41 @@ You can try Amazon Elasticbeanstalk by running through the following exercise [G
 
 2. Create a new user [here](https://console.aws.amazon.com/iam/home?#users) and add it to the previously create group
 
-3. Setup credentials for the beanstalk-maven-plugin as described [here](http://beanstalker.ingenieux.com.br/beanstalk-maven-plugin/security.html)
+3. Add permissions to the Default Instance Profile
+
+* Select role [aws-elasticbeanstalk-ec2-role](https://console.aws.amazon.com/iam/home?#roles/aws-elasticbeanstalk-ec2-role)
+* Attach [AmazonEC2ReadOnlyAccess](https://console.aws.amazon.com/iam/home?#policies/arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess) to it.
+
+4. Setup credentials for the beanstalk-maven-plugin as described [here](http://beanstalker.ingenieux.com.br/beanstalk-maven-plugin/security.html)
 
     ```
     $ export AWS_ACCESS_KEY_ID="<your aws access key>"
     $ export AWS_SECRET_KEY="<your aws secret key>"
     ```
 
-4. Create bucket `beanstalk-maven-plugin` on [Amazon S3](https://console.aws.amazon.com/s3/home)
+5. Create bucket `beanstalk-maven-plugin` on [Amazon S3](https://console.aws.amazon.com/s3/home)
 
-5. Check if the your chosen CNAME is available for your deployment
+    ```
+    $ export AWS_EB_S3_BUCKET_NAME="<your S3 bucket for beanstalk-maven-plugin>"
+    ```
+
+6. Check if the your chosen CNAME is available for your deployment
 
     ```
     mvn beanstalk:check-availability -DapplicationId=N
     ```
 
-6. If `amazon-elasticbeanstalk-N.us-east-1.elasticbeanstalk.com` is taken, try to increase `N` until you find an available CNAME.
+7. If `amazon-elasticbeanstalk-N.us-east-1.elasticbeanstalk.com` is taken, try to increase `N` until you find an available CNAME.
 
-7. Upload the bundle to the previously created S3 bucket and deploy the app to Elasticbeanstalk (this may take a while)
+8. Upload the bundle to the previously created S3 bucket and deploy the app to Elasticbeanstalk (this may take a while)
 
     ```
     mvn beanstalk:upload-source-bundle beanstalk:create-application-version beanstalk:create-environment -DapplicationId=N
     ```
 
-8. Go to [Security Groups](https://console.aws.amazon.com/ec2/v2/home#SecurityGroups:sort=groupName) on the EC2 management console and modify the one which was created for your environment. Add two rules: one for accepting HTTP connection from anywhere and another one for accepting all TCP traffic from 10.0.0.0/8. This latter is needed to make the nodes be to communicate to other.
+9. Go to [Security Groups](https://console.aws.amazon.com/ec2/v2/home#SecurityGroups:sort=groupName) on the EC2 management console and modify the one which was created for your environment. Add two rules: one for accepting HTTP connection from anywhere and another one for accepting all TCP traffic from 10.0.0.0/8 or 172.16.0.0/12 depending on your VPC settings. This latter is needed to make the nodes be to communicate to other.
 
-9. Find the two nodes of the newly created Elasticbeanstalk environment
+10. Find the two nodes of the newly created Elasticbeanstalk environment
 
     ```
     mvn beanstalk:dump-instances -DapplicationId=N

--- a/hazelcast-integration/amazon-elasticbeanstalk/README.md
+++ b/hazelcast-integration/amazon-elasticbeanstalk/README.md
@@ -1,0 +1,136 @@
+# Amazon Elasticbeanstalk Hazelcast
+
+## Introduction
+
+This project allows you to:
+
+- deploy a Hazelcast project onto Amazon Elasticbeanstalk using [beanstalk-maven-plugin](http://beanstalker.ingenieux.com.br/beanstalk-maven-plugin/usage.html)
+- demonstrate Hazelcast's auto discovery mechanisms for cluster formation in an Elasticbeanstalk environment
+
+## Assumptions
+
+This project is not intended as a beginners guide to Amazon Elasticbeanstalk, Hazelcast or Maven. If you are new to these tools, please familiarize yourself with them before proceeding.
+
+### Amazon Elasticbeanstalk
+
+You should have prior knowledge of Amazon Elasticbeanstalk; for example, you should know how to set up your own environment, maybe via the Elasticbeanstalk control panel.
+You can try Amazon Elasticbeanstalk by running through the following exercise [Getting Started Using Elastic Beanstalk](http://docs.aws.amazon.com/elasticbeanstalk/latest/dg/GettingStarted.html).
+
+## Required setup
+
+1. Go to [Amazon IAM](https://console.aws.amazon.com/iam/home) and create a new group with policies
+
+* [AmazonEC2ReadOnlyAccess](https://console.aws.amazon.com/iam/home?#policies/arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess)
+* [AmazonS3FullAccess](https://console.aws.amazon.com/iam/home?region=us-east-1#policies/arn:aws:iam::aws:policy/AmazonS3FullAccess)
+* [AWSElasticBeanstalkFullAccess](https://console.aws.amazon.com/iam/home?#policies/arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess)
+
+2. Create a new user [here](https://console.aws.amazon.com/iam/home?#users) and add it to the previously create group
+
+3. Setup credentials for the beanstalk-maven-plugin as described [here](http://beanstalker.ingenieux.com.br/beanstalk-maven-plugin/security.html)
+
+    ```
+    $ export AWS_ACCESS_KEY_ID="<your aws access key>"
+    $ export AWS_SECRET_KEY="<your aws secret key>"
+    ```
+
+4. Create bucket `beanstalk-maven-plugin` on [Amazon S3](https://console.aws.amazon.com/s3/home)
+
+5. Check if the your chosen CNAME is available for your deployment
+
+    ```
+    mvn beanstalk:check-availability -DapplicationId=N
+    ```
+
+6. If `amazon-elasticbeanstalk-N.us-east-1.elasticbeanstalk.com` is taken, try to increase `N` until you find an available CNAME.
+
+7. Upload the bundle to the previously created S3 bucket and deploy the app to Elasticbeanstalk (this may take a while)
+
+    ```
+    mvn beanstalk:upload-source-bundle beanstalk:create-application-version beanstalk:create-environment -DapplicationId=N
+    ```
+
+8. Go to [Security Groups](https://console.aws.amazon.com/ec2/v2/home#SecurityGroups:sort=groupName) on the EC2 management console and modify the one which was created for your environment. Add two rules: one for accepting HTTP connection from anywhere and another one for accepting all TCP traffic from 10.0.0.0/8. This latter is needed to make the nodes be to communicate to other.
+
+9. Find the two nodes of the newly created Elasticbeanstalk environment
+
+    ```
+    mvn beanstalk:dump-instances -DapplicationId=N
+    ```
+
+    If environment creation succeeded, you should get something like this.
+
+    ```
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Building amazon-elasticbeanstalk 0.1-SNAPSHOT
+    [INFO] ------------------------------------------------------------------------
+    [INFO]
+    [INFO] --- beanstalk-maven-plugin:1.5.0:dump-instances (default-cli) @ amazon-elasticbeanstalk ---
+    [INFO] ... with cname belonging to amazon-elasticbeanstalk-2.elasticbeanstalk.com or amazon-elasticbeanstalk-2.us-east-1.elasticbeanstalk.com
+    [INFO] ... with status *NOT* set to 'Terminated'
+    [INFO]  * i-437256c4: 54.159.177.5
+    [INFO]  * i-847ea91e: 54.198.1.61
+    [INFO] SUCCESS
+    [INFO] null/void result
+    [INFO] ------------------------------------------------------------------------
+    [INFO] BUILD SUCCESS
+    [INFO] ------------------------------------------------------------------------
+    [INFO] Total time: 5.193s
+    [INFO] Finished at: Fri May 13 15:14:31 CEST 2016
+    [INFO] Final Memory: 19M/308M
+    [INFO] ------------------------------------------------------------------------
+    ```
+
+## Trying it out
+
+With having the two individual nodes, we can test how they work together. The sample app contains a simple REST service.
+
+1. On one node we create an entry
+
+    ```
+    curl -v -H "Content-Type: application/json" -X POST http://54.159.177.5/entries -d '{"key":"key1", "value":"value1"}'
+    ```
+
+2. We can now fetch it from the another node
+
+    ```
+    curl -v http://54.198.1.61/entries/key1
+    ```
+
+3. Delete the entry
+
+    ```
+    curl -v -X DELETE http://54.198.1.61/entries/key1
+    ```
+
+4. Check it on the other node that it actually got deleted
+
+    ```
+    curl -v http://54.159.177.5/entries/key1
+    ```
+
+## Troubleshooting
+
+It can be that nodes cannot join due to firewall issues, in this case two one-node Hazelcast cluster will be formed.
+
+```
+INFO : com.hazelcast.nio.tcp.InitConnectionTask - [10.159.86.204]:5701 [amazon-elasticbeanstalk-1] [3.7-SNAPSHOT] Connecting to /10.185.55.223:5701, timeout: 0, bind-any: true
+INFO : com.hazelcast.nio.tcp.InitConnectionTask - [10.159.86.204]:5701 [amazon-elasticbeanstalk-1] [3.7-SNAPSHOT] Connecting to /10.185.55.223:5702, timeout: 0, bind-any: true
+INFO : com.hazelcast.nio.tcp.InitConnectionTask - [10.159.86.204]:5701 [amazon-elasticbeanstalk-1] [3.7-SNAPSHOT] Connecting to /10.185.55.223:5703, timeout: 0, bind-any: true
+...
+INFO : com.hazelcast.cluster.impl.TcpIpJoinerOverAWS - [10.159.86.204]:5701 [amazon-elasticbeanstalk-1] [3.7-SNAPSHOT]
+
+
+Members [1] {
+	Member [10.159.86.204]:5701 - a1ad88c2-1585-4d98-97e0-326558c03dfd this
+}
+
+INFO : com.hazelcast.core.LifecycleService - [10.159.86.204]:5701 [amazon-elasticbeanstalk-1] [3.7-SNAPSHOT] [10.159.86.204]:5701 is STARTED
+```
+
+## Finally
+
+Once you've finished experimenting within Amazon remember to stop everything, otherwise it can get very expensive leaving instances running.
+
+```
+mvn beanstalk:terminate-environment -DapplicationId=N
+```

--- a/hazelcast-integration/amazon-elasticbeanstalk/pom.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/pom.xml
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>war</packaging>
+
+    <artifactId>amazon-elasticbeanstalk</artifactId>
+    <name>amazon-elasticbeanstalk</name>
+    <url>http://maven.apache.org</url>
+
+    <parent>
+        <artifactId>hazelcast-integration</artifactId>
+        <groupId>com.hazelcast.samples</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <!-- customize applicationId here if there was a collision when checking with beanstalk:check-availability -->
+        <applicationId>1</applicationId>
+        <applicationName>${project.artifactId}-${applicationId}</applicationName>
+
+        <!-- needed for beanstalk-maven-plugin -->
+        <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
+        <beanstalk.applicationName>${applicationName}</beanstalk.applicationName>
+        <beanstalk.cnamePrefix>${applicationName}</beanstalk.cnamePrefix>
+        <beanstalk.environmentAwsAccessKeyId>${env.AWS_ACCESS_KEY_ID}</beanstalk.environmentAwsAccessKeyId>
+        <beanstalk.environmentAwsSecretKey>${env.AWS_SECRET_KEY}</beanstalk.environmentAwsSecretKey>
+        <beanstalk.environmentName>${applicationName}</beanstalk.environmentName>
+        <beanstalk.environmentRef>${applicationName}.elasticbeanstalk.com</beanstalk.environmentRef>
+        <beanstalk.instanceType>m1.small</beanstalk.instanceType>
+        <beanstalk.jvmXms>512m</beanstalk.jvmXms>
+        <beanstalk.jvmXmx>512m</beanstalk.jvmXmx>
+        <beanstalk.scalingMinSize>2</beanstalk.scalingMinSize>
+        <beanstalk.solutionStack>64bit Amazon Linux 2016.03 v2.1.1 running Tomcat 8 Java 8</beanstalk.solutionStack>
+        <beanstalk.versionLabel>${maven.build.timestamp}</beanstalk.versionLabel>
+
+        <aws-java-sdk-ec2.version>1.10.77</aws-java-sdk-ec2.version>
+        <cache-ri-impl.version>1.0.0</cache-ri-impl.version>
+        <jackson.version>2.6.6</jackson.version>
+        <slf4j.version>1.7.21</slf4j.version>
+        <spring.version>4.2.6.RELEASE</spring.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>${aws-java-sdk-ec2.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jsr107.ri</groupId>
+            <artifactId>cache-ri-impl</artifactId>
+            <version>${cache-ri-impl.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.0</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>br.com.ingenieux</groupId>
+                <artifactId>beanstalk-maven-plugin</artifactId>
+                <version>1.5.0</version>
+                <configuration>
+                    <s3Bucket>beanstalk-maven-plugin</s3Bucket>
+                    <s3Key>${project.artifactId}/${project.build.finalName}-${maven.build.timestamp}.war</s3Key>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/hazelcast-integration/amazon-elasticbeanstalk/pom.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- customize applicationId here if there was a collision when checking with beanstalk:check-availability -->
         <applicationId>1</applicationId>
-        <applicationName>${project.artifactId}-${applicationId}</applicationName>
+        <applicationName>hazelcast-${project.artifactId}-${applicationId}</applicationName>
 
         <!-- needed for beanstalk-maven-plugin -->
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
@@ -49,6 +49,7 @@
         <beanstalk.environmentAwsSecretKey>${env.AWS_SECRET_KEY}</beanstalk.environmentAwsSecretKey>
         <beanstalk.environmentName>${applicationName}</beanstalk.environmentName>
         <beanstalk.environmentRef>${applicationName}.elasticbeanstalk.com</beanstalk.environmentRef>
+        <beanstalk.iamInstanceProfile>aws-elasticbeanstalk-ec2-role</beanstalk.iamInstanceProfile>
         <beanstalk.instanceType>m1.small</beanstalk.instanceType>
         <beanstalk.jvmXms>512m</beanstalk.jvmXms>
         <beanstalk.jvmXmx>512m</beanstalk.jvmXmx>
@@ -122,7 +123,7 @@
                 <artifactId>beanstalk-maven-plugin</artifactId>
                 <version>1.5.0</version>
                 <configuration>
-                    <s3Bucket>beanstalk-maven-plugin</s3Bucket>
+                    <s3Bucket>${env.AWS_EB_S3_BUCKET_NAME}</s3Bucket>
                     <s3Key>${project.artifactId}/${project.build.finalName}-${maven.build.timestamp}.war</s3Key>
                 </configuration>
             </plugin>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/Entry.java
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/Entry.java
@@ -1,0 +1,77 @@
+/*
+ *
+ *  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.hazelcast.samples.amazon.elasticbeanstalk;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author László Csontos
+ */
+public class Entry {
+
+    public static final Entry NULL_ENTRY = new Entry();
+
+    private final String key;
+    private final String value;
+
+    public Entry() {
+        this(null, null);
+    }
+
+    @JsonCreator
+    public Entry(@JsonProperty("key") String key, @JsonProperty("value") String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+
+        if (obj == this) {
+            return true;
+        }
+
+        if (!(obj instanceof Entry)) {
+            return false;
+        }
+
+        Entry entry = (Entry) obj;
+        return Objects.equals(entry.key, key);
+    }
+
+    @Override
+    public int hashCode() {
+        return key.hashCode();
+    }
+
+}

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/HazelcastController.java
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/HazelcastController.java
@@ -1,0 +1,105 @@
+/*
+ *
+ *  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.hazelcast.samples.amazon.elasticbeanstalk;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.OK;
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
+/**
+ * @author László Csontos
+ */
+@RestController
+public class HazelcastController implements InitializingBean {
+
+    private static final ResponseEntity<Entry> EMPTY_RESPONSE = new ResponseEntity<Entry>(Entry.NULL_ENTRY, OK);
+
+    @Autowired
+    private HazelcastInstance instance;
+
+    private IMap<String, String> hzMap;
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        hzMap = instance.getMap("hzMap");
+    }
+
+    @RequestMapping(method = POST, value = "/entries")
+    public ResponseEntity<Entry> putIfAbsent(@RequestBody Entry entry) {
+        if (entry == null) {
+            return new ResponseEntity<Entry>(BAD_REQUEST);
+        }
+        String oldValue = hzMap.putIfAbsent(entry.getKey(), entry.getValue());
+        if (oldValue == null) {
+            return EMPTY_RESPONSE;
+        }
+        return createResponseEntity(entry.getKey(), oldValue);
+    }
+
+    @RequestMapping(method = DELETE, value = "/entries/{key}")
+    public ResponseEntity<Entry> remove(@PathVariable String key) {
+        String value = hzMap.remove(key);
+        if (value == null) {
+            return new ResponseEntity<Entry>(NOT_FOUND);
+        }
+        return createResponseEntity(key, value);
+    }
+
+    @RequestMapping(method = GET, value = "/entries/{key}")
+    public ResponseEntity<Entry> get(@PathVariable String key) {
+        String value = hzMap.get(key);
+        if (value == null) {
+            return new ResponseEntity<Entry>(NOT_FOUND);
+        }
+        return createResponseEntity(key, value);
+    }
+
+    @RequestMapping(method = GET, value = "/entries")
+    public ResponseEntity<Set<Entry>> entrySet() {
+        Set<Map.Entry<String, String>> hzMapEntries = hzMap.entrySet();
+        Set<Entry> entrySet = new HashSet<Entry>(hzMapEntries.size());
+        for (Map.Entry<String, String> entry : hzMapEntries) {
+            entrySet.add(new Entry(entry.getKey(), entry.getValue()));
+        }
+        return new ResponseEntity<Set<Entry>>(entrySet, OK);
+    }
+
+    private ResponseEntity<Entry> createResponseEntity(String key, String value) {
+        return new ResponseEntity<Entry>(new Entry(key, value), OK);
+    }
+
+}

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/HazelcastInstanceFactory.java
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/java/com/hazelcast/samples/amazon/elasticbeanstalk/HazelcastInstanceFactory.java
@@ -1,0 +1,195 @@
+/*
+ *
+ *  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.hazelcast.samples.amazon.elasticbeanstalk;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeTagsRequest;
+import com.amazonaws.services.ec2.model.DescribeTagsResult;
+import com.amazonaws.services.ec2.model.Filter;
+import com.amazonaws.util.EC2MetadataUtils;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.XmlConfigBuilder;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.spring.context.SpringManagedContext;
+import com.hazelcast.util.MD5Util;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.config.AbstractFactoryBean;
+import org.springframework.core.io.Resource;
+import org.springframework.util.StringUtils;
+
+/**
+ * @author László Csontos
+ */
+public class HazelcastInstanceFactory extends AbstractFactoryBean<HazelcastInstance> {
+
+    public static final String ELASTICBEANSTALK_ENVIRONMENT_NAME = "elasticbeanstalk:environment-name";
+    public static final String HAZELCAST_ENVIRONMENT_NAME = "hazelcast.environment.name";
+    public static final String HAZELCAST_ENVIRONMENT_PASSWORD = "hazelcast.environment.password";
+    public static final String HAZELCAST_AWS_ACCESS_KEY = "hazelcast.aws.access-key";
+    public static final String HAZELCAST_AWS_SECRET_KEY = "hazelcast.aws.secret-key";
+    public static final String HAZELCAST_AWS_REGION = "hazelcast.aws.region";
+    public static final String HAZELCAST_LOGGING_TYPE = "hazelcast.logging.type";
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(HazelcastInstanceFactory.class);
+
+    private final String accessKeyId;
+    private final String secretKey;
+
+    private AmazonEC2 amazonEC2;
+    private boolean localOnly;
+
+    @Value("classpath:/hazelcast-aws.xml")
+    private Resource hazelcastAWSConfig;
+
+    @Value("classpath:/hazelcast-local.xml")
+    private Resource hazelcastLocalConfig;
+
+    @Autowired
+    private SpringManagedContext springManagedContext;
+
+    public HazelcastInstanceFactory(String accessKeyId, String secretKey) {
+        this.accessKeyId = accessKeyId;
+        this.secretKey = secretKey;
+
+        if (StringUtils.hasText(accessKeyId) && StringUtils.hasText(secretKey)) {
+            AWSCredentials credentials = new BasicAWSCredentials(accessKeyId, secretKey);
+            amazonEC2 = new AmazonEC2Client(credentials);
+        } else {
+            LOGGER.warn("AWS access or secret key are empty, local cluster configuration will be used.");
+        }
+    }
+
+    @Override
+    public Class<HazelcastInstance> getObjectType() {
+        return HazelcastInstance.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    @Override
+    protected HazelcastInstance createInstance() throws Exception {
+        Config config = getConfig();
+        config.setProperty(HAZELCAST_LOGGING_TYPE, "slf4j");
+
+        // Enabling @SpringAware by default was causing performance hit so it had been disabled as of 3.5-EA.
+        // Although <hz:spring-aware /> makes it possible to enable @SpringAware, it's not an option for programmatic
+        // configuration.
+        // See https://github.com/hazelcast/hazelcast/issues/5323#issuecomment-103033381
+        // See https://github.com/hazelcast/hazelcast/issues/6514#issuecomment-180394893
+        config.setManagedContext(springManagedContext);
+
+        return Hazelcast.newHazelcastInstance(config);
+    }
+
+    @Override
+    protected void destroyInstance(HazelcastInstance hazelcastInstance) throws Exception {
+        hazelcastInstance.shutdown();
+        shutdownAmazonEC2();
+    }
+
+    protected Config getConfig() throws IOException {
+        Properties awsProperties = null;
+        if (amazonEC2 != null) {
+            try {
+                awsProperties = getAwsProperties();
+            } catch (RuntimeException re) {
+                shutdownAmazonEC2();
+                LOGGER.error(
+                        "Auto-detecting cluster membership has failed; falling back to local configuration.", re);
+            }
+        }
+
+        Resource hazelcastConfig = (amazonEC2 != null) ? hazelcastAWSConfig : hazelcastLocalConfig;
+        LOGGER.info("Using {} for cluster configuration.", hazelcastConfig.getFilename());
+
+        XmlConfigBuilder xmlConfigBuilder = new XmlConfigBuilder(hazelcastConfig.getInputStream());
+        if (amazonEC2 != null) {
+            xmlConfigBuilder.setProperties(awsProperties);
+        }
+        return xmlConfigBuilder.build();
+    }
+
+    protected Properties getAwsProperties() {
+        EC2MetadataUtils.InstanceInfo instanceInfo = EC2MetadataUtils.getInstanceInfo();
+        String instanceId = instanceInfo.getInstanceId();
+
+        // EB sets the environment ID and name as the elasticbeanstalk:environment-id and
+        // elasticbeanstalk:environment-name EC2 tags on all of the parts of an EB app environment: load balancer,
+        // EC2 instances, security groups, etc. Surprisingly, EC2 tags aren’t available to instances through the
+        // instance metadata interface, but they are available through the normal AWS API’s DescribeTags call.
+        Collection<Filter> filters = new ArrayList<Filter>();
+        filters.add(new Filter("resource-type").withValues("instance"));
+        filters.add(new Filter("resource-id").withValues(instanceId));
+        filters.add(new Filter("key").withValues(ELASTICBEANSTALK_ENVIRONMENT_NAME));
+
+        DescribeTagsRequest describeTagsRequest = new DescribeTagsRequest();
+        describeTagsRequest.setFilters(filters);
+        DescribeTagsResult describeTagsResult = amazonEC2.describeTags(describeTagsRequest);
+
+        if (describeTagsResult == null || describeTagsResult.getTags().isEmpty()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("No tag ");
+            sb.append(ELASTICBEANSTALK_ENVIRONMENT_NAME);
+            sb.append(" found for instance ");
+            sb.append(instanceId);
+            sb.append(".");
+
+            throw new IllegalStateException(sb.toString());
+        }
+
+        String environmentName = describeTagsResult.getTags().get(0).getValue();
+        String environmentPassword = MD5Util.toMD5String(environmentName);
+
+        Properties properties = new Properties();
+        properties.setProperty(HAZELCAST_ENVIRONMENT_NAME, environmentName);
+        properties.setProperty(HAZELCAST_ENVIRONMENT_PASSWORD, environmentPassword);
+        properties.setProperty(HAZELCAST_AWS_ACCESS_KEY, accessKeyId);
+        properties.setProperty(HAZELCAST_AWS_SECRET_KEY, secretKey);
+        properties.setProperty(HAZELCAST_AWS_REGION, instanceInfo.getRegion());
+
+        return properties;
+    }
+
+    protected void shutdownAmazonEC2() {
+        if (amazonEC2 == null) {
+            return;
+        }
+        amazonEC2.shutdown();
+        amazonEC2 = null;
+    }
+
+}

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-aws.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-aws.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<hazelcast
+        xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd"
+        xmlns="http://www.hazelcast.com/schema/config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <group>
+        <name>${hazelcast.environment.name}</name>
+        <password>${hazelcast.environment.password}</password>
+    </group>
+    <network>
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="false"/>
+            <aws enabled="true">
+                <access-key>${hazelcast.aws.access-key}</access-key>
+                <secret-key>${hazelcast.aws.secret-key}</secret-key>
+                <region>${hazelcast.aws.region}</region>
+                <tag-key>elasticbeanstalk:environment-name</tag-key>
+                <tag-value>${hazelcast.environment.name}</tag-value>
+            </aws>
+        </join>
+    </network>
+</hazelcast>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-aws.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-aws.xml
@@ -30,8 +30,7 @@
             <multicast enabled="false"/>
             <tcp-ip enabled="false"/>
             <aws enabled="true">
-                <access-key>${hazelcast.aws.access-key}</access-key>
-                <secret-key>${hazelcast.aws.secret-key}</secret-key>
+                <iam-role>${hazelcast.aws.iam-role}</iam-role>
                 <region>${hazelcast.aws.region}</region>
                 <tag-key>elasticbeanstalk:environment-name</tag-key>
                 <tag-value>${hazelcast.environment.name}</tag-value>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-local.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/hazelcast-local.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<hazelcast
+        xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.6.xsd"
+        xmlns="http://www.hazelcast.com/schema/config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <group>
+        <name>dev</name>
+        <password>dev-pass</password>
+    </group>
+    <network>
+        <join>
+            <multicast enabled="false"/>
+            <tcp-ip enabled="true">
+                <interface>127.0.0.1</interface>
+                <member-list>
+                    <member>127.0.0.1</member>
+                </member-list>
+            </tcp-ip>
+        </join>
+    </network>
+</hazelcast>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/log4j.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/log4j.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<!DOCTYPE log4j:configuration PUBLIC "-//APACHE//DTD LOG4J 1.2//EN" "log4j.dtd">
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+
+    <!-- Appenders -->
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p: %c - %m%n"/>
+        </layout>
+    </appender>
+
+    <!-- Hazelcast Loggers -->
+    <logger name="com.hazelcast">
+        <level value="info"/>
+    </logger>
+
+    <logger name="com.hazelcast.samples">
+        <level value="debug"/>
+    </logger>
+
+    <!-- Spring Loggers -->
+    <logger name="org.springframework.core">
+        <level value="info"/>
+    </logger>
+
+    <logger name="org.springframework.beans">
+        <level value="info"/>
+    </logger>
+
+    <logger name="org.springframework.context">
+        <level value="info"/>
+    </logger>
+
+    <logger name="org.springframework.web">
+        <level value="info"/>
+    </logger>
+
+    <!-- Root Logger -->
+    <root>
+        <priority value="warn"/>
+        <appender-ref ref="console"/>
+    </root>
+
+</log4j:configuration>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-hazelcast.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-hazelcast.xml
@@ -23,9 +23,6 @@
 
     <bean id="springManagedContext" class="com.hazelcast.spring.context.SpringManagedContext" />
 
-    <bean id="hazelcastInstance" class="com.hazelcast.samples.amazon.elasticbeanstalk.HazelcastInstanceFactory">
-        <constructor-arg type="java.lang.String" value="${AWS_ACCESS_KEY_ID:#{null}}"/>
-        <constructor-arg type="java.lang.String" value="${AWS_SECRET_KEY:#{null}}"/>
-    </bean>
+    <bean id="hazelcastInstance" class="com.hazelcast.samples.amazon.elasticbeanstalk.HazelcastInstanceFactory" />
 
 </beans>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-hazelcast.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-hazelcast.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="springManagedContext" class="com.hazelcast.spring.context.SpringManagedContext" />
+
+    <bean id="hazelcastInstance" class="com.hazelcast.samples.amazon.elasticbeanstalk.HazelcastInstanceFactory">
+        <constructor-arg type="java.lang.String" value="${AWS_ACCESS_KEY_ID:#{null}}"/>
+        <constructor-arg type="java.lang.String" value="${AWS_SECRET_KEY:#{null}}"/>
+    </bean>
+
+</beans>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-mvc.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/resources/spring-mvc.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+        http://www.springframework.org/schema/mvc http://www.springframework.org/schema/mvc/spring-mvc.xsd
+        http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+
+    <context:annotation-config/>
+    <context:component-scan base-package="com.hazelcast.samples.amazon.elasticbeanstalk"/>
+    <context:property-placeholder />
+
+    <mvc:annotation-driven>
+        <mvc:message-converters>
+            <bean class="org.springframework.http.converter.json.MappingJackson2HttpMessageConverter">
+                <property name="supportedMediaTypes" value = "application/json" />
+                <property name="objectMapper">
+                    <bean class="org.springframework.http.converter.json.Jackson2ObjectMapperFactoryBean">
+                        <property name="failOnUnknownProperties" value="true"/>
+                        <property name="indentOutput" value="true"/>
+                    </bean>
+                </property>
+            </bean>
+            <bean class="org.springframework.http.converter.StringHttpMessageConverter">
+                <property name="supportedMediaTypes" value = "text/plain;charset=UTF-8" />
+            </bean>
+        </mvc:message-converters>
+    </mvc:annotation-driven>
+
+</beans>

--- a/hazelcast-integration/amazon-elasticbeanstalk/src/main/webapp/WEB-INF/web.xml
+++ b/hazelcast-integration/amazon-elasticbeanstalk/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~
+  ~  Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+  ~
+  ~  Licensed under the Apache License, Version 2.0 (the "License");
+  ~  you may not use this file except in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~  http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing, software
+  ~  distributed under the License is distributed on an "AS IS" BASIS,
+  ~  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~  See the License for the specific language governing permissions and
+  ~  limitations under the License.
+  ~
+  -->
+
+<web-app
+        id="WebApp_ID"
+        version="3.0"
+        xmlns="http://java.sun.com/xml/ns/javaee"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="
+        http://java.sun.com/xml/ns/javaee
+        http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+  <display-name>Sample Hazelcast integration app on AWS Elasticbeanstalk</display-name>
+
+    <context-param>
+        <param-name>contextConfigLocation</param-name>
+        <param-value>classpath*:/spring-*.xml</param-value>
+    </context-param>
+
+    <listener>
+        <listener-class>org.springframework.web.context.ContextLoaderListener</listener-class>
+    </listener>
+
+    <servlet>
+        <servlet-name>DispatcherServlet</servlet-name>
+        <servlet-class>org.springframework.web.servlet.DispatcherServlet</servlet-class>
+        <init-param>
+            <param-name>contextConfigLocation</param-name>
+            <param-value></param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>DispatcherServlet</servlet-name>
+        <url-pattern>/</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/hazelcast-integration/pom.xml
+++ b/hazelcast-integration/pom.xml
@@ -39,6 +39,7 @@
 
     <modules>
         <module>amazon-ec2-vagrant-chef</module>
+        <module>amazon-elasticbeanstalk</module>
         <module>filter-based-session-replication</module>
         <module>hibernate-2ndlevel-cache</module>
         <module>hibernate-jpa-2ndlevel-cache</module>


### PR DESCRIPTION
Hi,

This an integration example how Hazelcast can be deployed in an Amazon Elasticbeanstalk environment. The code sample can also be used in local mode, if either system property `AWS_ACCESS_KEY_ID` or `AWS_SECRET_KEY` is missing.

Currently `com.hazelcast.samples.amazon.elasticbeanstalk.HazelcastInstanceFactory` closely mirrors what I now use in production. Nevertheless, there is an open feature request (https://github.com/hazelcast/hazelcast/issues/8031) for enabling Hazelcast to do this out of the box, without having to look up the EB environment name manually.

By the time changes for https://github.com/hazelcast/hazelcast/issues/8031 will have been committed, I'll modify this sample code to demonstrate, Hazelcast's new ability to auto-detect member in an EB environment.

Thanks for reviewing!

Cheers,
László
