### PR TITLE
Added LicenseUtils to ease settings of Hazelcast Enterprise License key in EE code samples

### DIFF
--- a/enterprise/client-ssl/src/main/java/Client.java
+++ b/enterprise/client-ssl/src/main/java/Client.java
@@ -6,21 +6,25 @@ import com.hazelcast.core.HazelcastInstance;
 import java.io.File;
 import java.util.concurrent.BlockingQueue;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class Client {
 
     public static void main(String[] args) throws Exception {
-        ClientConfig clientConfig = new ClientConfig();
-
-        // please set your enterprise license key to make the sample work
-        clientConfig.setLicenseKey("YOUR_ENTERPRISE_LICENSE_KEY");
-
-        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
         SSLConfig sslConfig = new SSLConfig();
         sslConfig.setEnabled(true);
         sslConfig.setFactoryClassName("com.hazelcast.nio.ssl.BasicSSLContextFactory");
         sslConfig.setProperty("keyStore", new File("enterprise/client-ssl/hazelcast.ks").getAbsolutePath());
         sslConfig.setProperty("keyStorePassword", "password");
         sslConfig.setProperty("javax.net.ssl.trustStore", new File("enterprise/client-ssl/hazelcast.ts").getAbsolutePath());
+
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+        clientConfig.getNetworkConfig().addAddress("127.0.0.1");
         clientConfig.getNetworkConfig().setSSLConfig(sslConfig);
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);

--- a/enterprise/client-ssl/src/main/java/Member.java
+++ b/enterprise/client-ssl/src/main/java/Member.java
@@ -6,20 +6,24 @@ import com.hazelcast.core.HazelcastInstance;
 import java.io.File;
 import java.util.concurrent.BlockingQueue;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class Member {
 
     public static void main(String[] args) throws Exception {
-        Config config = new Config();
-
-        // please set your enterprise license key to make the sample work
-        config.setLicenseKey("YOUR_ENTERPRISE_LICENSE_KEY");
-
         SSLConfig sslConfig = new SSLConfig();
         sslConfig.setEnabled(true);
         sslConfig.setFactoryClassName("com.hazelcast.nio.ssl.BasicSSLContextFactory");
         sslConfig.setProperty("keyStore", new File("enterprise/client-ssl/hazelcast.ks").getAbsolutePath());
         sslConfig.setProperty("keyStorePassword", "password");
         sslConfig.setProperty("javax.net.ssl.trustStore", new File("enterprise/client-ssl/hazelcast.ts").getAbsolutePath());
+
+        Config config = new Config();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         config.getNetworkConfig().setSSLConfig(sslConfig);
 
         HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);

--- a/enterprise/continuous-query-cache/src/main/java/ClientServer.java
+++ b/enterprise/continuous-query-cache/src/main/java/ClientServer.java
@@ -1,5 +1,6 @@
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.config.Config;
 import com.hazelcast.config.QueryCacheConfig;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
@@ -11,9 +12,14 @@ import com.hazelcast.query.Predicate;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
  * This example demonstrates the usage of a continuous-query-cache (CQC) from Hazelcast client.
  * Also in this example you can see how a CQC is configured from client side.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class ClientServer {
 
@@ -21,14 +27,19 @@ public class ClientServer {
         String mapName = "mapName";
         String cacheName = "cqc";
 
-        HazelcastInstance hz = Hazelcast.newHazelcastInstance();
-        Hazelcast.newHazelcastInstance();
+        Config config = new Config();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
+        HazelcastInstance hz = Hazelcast.newHazelcastInstance(config);
+        Hazelcast.newHazelcastInstance(config);
 
         QueryCacheConfig queryCacheConfig = new QueryCacheConfig(cacheName);
         queryCacheConfig.getPredicateConfig().setImplementation(new OddKeysPredicate());
 
         ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         clientConfig.addQueryCacheConfig(mapName, queryCacheConfig);
+
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
         IEnterpriseMap<Integer, Integer> clientMap = (IEnterpriseMap) client.getMap(mapName);
@@ -62,7 +73,6 @@ public class ClientServer {
             Hazelcast.shutdownAll();
         }
     }
-
 
     private static class OddKeysPredicate implements Predicate<Integer, Integer> {
 

--- a/enterprise/continuous-query-cache/src/main/java/Peer2Peer.java
+++ b/enterprise/continuous-query-cache/src/main/java/Peer2Peer.java
@@ -1,3 +1,4 @@
+import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IEnterpriseMap;
@@ -6,14 +7,22 @@ import com.hazelcast.query.SqlPredicate;
 
 import java.util.concurrent.TimeUnit;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
  * This example demonstrates the simple usage of a continuous-query-cache feature in a peer-to-peer application.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class Peer2Peer {
 
     public static void main(String[] args) {
-        HazelcastInstance node = Hazelcast.newHazelcastInstance();
-        Hazelcast.newHazelcastInstance();
+        Config config = new Config();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
+        HazelcastInstance node = Hazelcast.newHazelcastInstance(config);
+        Hazelcast.newHazelcastInstance(config);
 
         IEnterpriseMap<Integer, String> map = (IEnterpriseMap) node.getMap("test");
         QueryCache<Integer, String> cache = map.getQueryCache("myCache", new SqlPredicate("__key > 3 and __key < 84"), true);

--- a/enterprise/hd-imap/src/main/java/HDEviction.java
+++ b/enterprise/hd-imap/src/main/java/HDEviction.java
@@ -11,11 +11,15 @@ import com.hazelcast.memory.MemoryUnit;
 
 import java.util.Map;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 import static com.hazelcast.config.MaxSizeConfig.MaxSizePolicy.PER_NODE;
 
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class HDEviction {
 
-    private static final String LICENSE_KEY = "";
     private static final int MAX_ENTRY_COUNT = 1000;
 
     public static void main(String[] args) {
@@ -52,9 +56,7 @@ public class HDEviction {
         Config config = new Config();
         config.addMapConfig(mapConfig);
         config.setNativeMemoryConfig(memoryConfig);
-        if (!LICENSE_KEY.isEmpty()) {
-            config.setLicenseKey(LICENSE_KEY);
-        }
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         return config;
     }

--- a/enterprise/hd-imap/src/main/java/HDSimplePopulation.java
+++ b/enterprise/hd-imap/src/main/java/HDSimplePopulation.java
@@ -9,9 +9,13 @@ import com.hazelcast.memory.MemoryUnit;
 
 import java.util.Map;
 
-public class HDSimplePopulation {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class HDSimplePopulation {
 
     public static void main(String[] args) {
         HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(newConfig());
@@ -40,9 +44,7 @@ public class HDSimplePopulation {
         Config config = new Config();
         config.addMapConfig(mapConfig);
         config.setNativeMemoryConfig(memoryConfig);
-        if (!LICENSE_KEY.isEmpty()) {
-            config.setLicenseKey(LICENSE_KEY);
-        }
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         return config;
     }

--- a/enterprise/hd-imap/src/main/java/nearcache/ClientHDNearCache.java
+++ b/enterprise/hd-imap/src/main/java/nearcache/ClientHDNearCache.java
@@ -11,14 +11,17 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.memory.MemorySize;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType.STANDARD;
 import static com.hazelcast.memory.MemoryUnit.MEGABYTES;
 
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class ClientHDNearCache {
-
-    private static final String LICENSE_KEY = "";
 
     public static void main(String[] args) {
         // start server
@@ -44,11 +47,9 @@ public class ClientHDNearCache {
         server.shutdown();
     }
 
-    public static Config newConfig() {
+    private static Config newConfig() {
         Config config = new Config();
-        if (!LICENSE_KEY.isEmpty()) {
-            config.setLicenseKey(LICENSE_KEY);
-        }
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         return config;
     }
@@ -71,9 +72,7 @@ public class ClientHDNearCache {
         ClientConfig clientConfig = new ClientConfig();
         clientConfig.setNativeMemoryConfig(memoryConfig);
         clientConfig.addNearCacheConfig(nearCacheConfig);
-        if (!LICENSE_KEY.isEmpty()) {
-            clientConfig.setLicenseKey(LICENSE_KEY);
-        }
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         return clientConfig;
     }

--- a/enterprise/hd-imap/src/main/java/nearcache/ServerHDNearCache.java
+++ b/enterprise/hd-imap/src/main/java/nearcache/ServerHDNearCache.java
@@ -10,14 +10,17 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
 import com.hazelcast.memory.MemorySize;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 import static com.hazelcast.config.EvictionConfig.MaxSizePolicy.USED_NATIVE_MEMORY_PERCENTAGE;
 import static com.hazelcast.config.InMemoryFormat.NATIVE;
 import static com.hazelcast.config.NativeMemoryConfig.MemoryAllocatorType.STANDARD;
 import static com.hazelcast.memory.MemoryUnit.MEGABYTES;
 
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class ServerHDNearCache {
-
-    private static final String LICENSE_KEY = "";
 
     public static void main(String[] args) {
         HazelcastInstance node = Hazelcast.newHazelcastInstance(newConfig());
@@ -59,9 +62,7 @@ public class ServerHDNearCache {
         Config config = new Config();
         config.addMapConfig(mapConfig);
         config.setNativeMemoryConfig(memoryConfig);
-        if (!LICENSE_KEY.isEmpty()) {
-            config.setLicenseKey(LICENSE_KEY);
-        }
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         return config;
     }

--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/java/EnterpriseCacheTestClient.java
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/java/EnterpriseCacheTestClient.java
@@ -22,6 +22,12 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public final class EnterpriseCacheTestClient {
 
     private static final String NAMESPACE = "test";
@@ -53,6 +59,7 @@ public final class EnterpriseCacheTestClient {
                                       int valueMin, int valueMax, long duration) throws IOException {
         InputStream configInputStream = EnterpriseCacheTestClient.class.getResourceAsStream("/hazelcast-client-hd-memory.xml");
         ClientConfig clientConfig = new XmlClientConfigBuilder(configInputStream).build();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         this.instance = HazelcastClient.newHazelcastClient(clientConfig);
         this.cacheManager = HazelcastClientCachingProvider.createCachingProvider(instance).getCacheManager();

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/java/EnterpriseCacheTestServer.java
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/java/EnterpriseCacheTestServer.java
@@ -11,8 +11,13 @@ import com.hazelcast.memory.MemoryUnit;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
  * A simple test of a cache.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public final class EnterpriseCacheTestServer {
 
@@ -34,15 +39,16 @@ public final class EnterpriseCacheTestServer {
         this.memorySize = MemorySize.parse(memory, MemoryUnit.GIGABYTES);
 
         InputStream configInputStream = EnterpriseCacheTestServer.class.getResourceAsStream("/hazelcast-hd-memory.xml");
-        Config cfg = new XmlConfigBuilder(configInputStream).build();
+        Config config = new XmlConfigBuilder(configInputStream).build();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
-        NativeMemoryConfig memoryConfig = cfg.getNativeMemoryConfig();
+        NativeMemoryConfig memoryConfig = config.getNativeMemoryConfig();
         if (!memoryConfig.isEnabled()) {
             memoryConfig.setSize(memorySize).setEnabled(true);
             memoryConfig.setAllocatorType(NativeMemoryConfig.MemoryAllocatorType.POOLED);
         }
 
-        instance = Hazelcast.newHazelcastInstance(cfg);
+        instance = Hazelcast.newHazelcastInstance(config);
         memoryStats = MemoryStatsUtil.getMemoryStats(instance);
         logger = instance.getLoggingService().getLogger(EnterpriseCacheTestServer.class);
     }

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/resources/hazelcast-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/resources/hazelcast-hd-memory.xml
@@ -24,9 +24,6 @@
         <password>dev-pass</password>
     </group>
 
-    <!-- request trial key at http://hazelcast.com/hazelcast-enterprise-trial/ -->
-    <license-key>YOUR_ENTERPRISE_KEY</license-key>
-
     <!-- management center is disabled by default -->
     <management-center enabled="false" update-interval="3">http://localhost:8080/mancenter/</management-center>
 

--- a/enterprise/hidensity-cache/src/main/java/HiDensityCacheIteratorUsage.java
+++ b/enterprise/hidensity-cache/src/main/java/HiDensityCacheIteratorUsage.java
@@ -5,6 +5,9 @@ import java.util.Iterator;
 
 /**
  * HiDensity cache {@link Iterator} usage example.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class HiDensityCacheIteratorUsage extends HiDensityCacheUsageSupport {
 

--- a/enterprise/hidensity-cache/src/main/java/HiDensityCachePutGetReplaceRemoveClearUsage.java
+++ b/enterprise/hidensity-cache/src/main/java/HiDensityCachePutGetReplaceRemoveClearUsage.java
@@ -4,6 +4,9 @@ import java.util.concurrent.Future;
 
 /**
  * HiDensity cache put/get/remove usage example.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class HiDensityCachePutGetReplaceRemoveClearUsage extends HiDensityCacheUsageSupport {
 

--- a/enterprise/hidensity-cache/src/main/java/HiDensityCacheTTLUsage.java
+++ b/enterprise/hidensity-cache/src/main/java/HiDensityCacheTTLUsage.java
@@ -8,6 +8,9 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * HiDensity cache TTL usage example.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class HiDensityCacheTTLUsage extends HiDensityCacheUsageSupport {
 

--- a/enterprise/hidensity-cache/src/main/java/HiDensityCacheUsageSupport.java
+++ b/enterprise/hidensity-cache/src/main/java/HiDensityCacheUsageSupport.java
@@ -15,12 +15,12 @@ import javax.cache.Cache;
 import javax.cache.CacheManager;
 import javax.cache.spi.CachingProvider;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
  * Support class for HiDensity cache usage examples.
  */
 abstract class HiDensityCacheUsageSupport {
-
-    private static final String LICENSE_KEY;
 
     /**
      * It is advised using native memory (off-heap) serialization
@@ -40,18 +40,12 @@ abstract class HiDensityCacheUsageSupport {
     @SuppressWarnings("checkstyle:explicitinitialization")
     private static boolean useNativeMemorySerialization = false;
 
-    static {
-        // Pass your license key as system property like:
-        // -Dhazelcast.enterprise.license.key=<YOUR_LICENCE_KEY_HERE>
-        LICENSE_KEY = System.getProperty("hazelcast.enterprise.license.key");
-    }
-
     private static HazelcastInstance instance;
     private static CacheManager cacheManager;
 
     private static Config createConfig() {
         return new Config()
-                .setLicenseKey(LICENSE_KEY)
+                .setLicenseKey(ENTERPRISE_LICENSE_KEY)
                 .setNativeMemoryConfig(createMemoryConfig())
                 .setSerializationConfig(createSerializationConfig());
     }

--- a/enterprise/hidensity-cache/src/main/java/nearcache/ClientHiDensityNearCacheUsage.java
+++ b/enterprise/hidensity-cache/src/main/java/nearcache/ClientHiDensityNearCacheUsage.java
@@ -4,6 +4,10 @@ import com.hazelcast.config.NearCacheConfig;
 
 import java.util.concurrent.TimeUnit;
 
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class ClientHiDensityNearCacheUsage extends ClientHiDensityNearCacheUsageSupport {
 
     private static final int RECORD_COUNT = 1000;

--- a/enterprise/hidensity-cache/src/main/java/nearcache/ClientHiDensityNearCacheUsageSupport.java
+++ b/enterprise/hidensity-cache/src/main/java/nearcache/ClientHiDensityNearCacheUsageSupport.java
@@ -20,12 +20,10 @@ import com.hazelcast.nio.serialization.EnterpriseSerializationService;
 
 import javax.cache.spi.CachingProvider;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 @SuppressWarnings("unused")
 abstract class ClientHiDensityNearCacheUsageSupport extends ClientNearCacheUsageSupport {
-
-    // pass your license key as system property like:
-    // -Dhazelcast.enterprise.license.key=<YOUR_LICENCE_KEY_HERE>
-    private static final String LICENSE_KEY = System.getProperty("hazelcast.enterprise.license.key");
 
     private static final MemorySize SERVER_NATIVE_MEMORY_SIZE = new MemorySize(256, MemoryUnit.MEGABYTES);
     private static final MemorySize CLIENT_NATIVE_MEMORY_SIZE = new MemorySize(128, MemoryUnit.MEGABYTES);
@@ -34,23 +32,29 @@ abstract class ClientHiDensityNearCacheUsageSupport extends ClientNearCacheUsage
         super(InMemoryFormat.NATIVE);
     }
 
+    @Override
     protected Config createConfig() {
         Config config = super.createConfig();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
         NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
                 .setSize(SERVER_NATIVE_MEMORY_SIZE)
                 .setEnabled(true);
         config.setNativeMemoryConfig(nativeMemoryConfig);
-        config.setLicenseKey(LICENSE_KEY);
+
         return config;
     }
 
+    @Override
     protected ClientConfig createClientConfig() {
         ClientConfig clientConfig = super.createClientConfig();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
         NativeMemoryConfig nativeMemoryConfig = new NativeMemoryConfig()
                 .setSize(CLIENT_NATIVE_MEMORY_SIZE)
                 .setEnabled(true);
         clientConfig.setNativeMemoryConfig(nativeMemoryConfig);
-        clientConfig.setLicenseKey(LICENSE_KEY);
+
         return clientConfig;
     }
 

--- a/enterprise/hot-restart/src/main/java/JCacheHotRestart.java
+++ b/enterprise/hot-restart/src/main/java/JCacheHotRestart.java
@@ -11,9 +11,13 @@ import javax.cache.Cache;
 import javax.cache.spi.CachingProvider;
 import java.io.File;
 
-public class JCacheHotRestart {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "---- LICENSE KEY ----";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class JCacheHotRestart {
 
     private static final String HOT_RESTART_ROOT_DIR = System.getProperty("java.io.tmpdir")
             + File.separatorChar + "hazelcast-hot-restart";
@@ -22,7 +26,7 @@ public class JCacheHotRestart {
         IOUtil.delete(new File(HOT_RESTART_ROOT_DIR));
 
         Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         config.getNetworkConfig().setPort(5701).setPortAutoIncrement(false);
         JoinConfig join = config.getNetworkConfig().getJoin();

--- a/enterprise/hot-restart/src/main/java/JCacheHotRestartMultipleNodes.java
+++ b/enterprise/hot-restart/src/main/java/JCacheHotRestartMultipleNodes.java
@@ -12,9 +12,13 @@ import javax.cache.Cache;
 import javax.cache.spi.CachingProvider;
 import java.io.File;
 
-public class JCacheHotRestartMultipleNodes {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "---- LICENSE KEY ----";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class JCacheHotRestartMultipleNodes {
 
     private static final String HOT_RESTART_ROOT_DIR = System.getProperty("java.io.tmpdir")
             + File.separatorChar + "hazelcast-hot-restart";
@@ -54,7 +58,7 @@ public class JCacheHotRestartMultipleNodes {
 
     private static HazelcastInstance newHazelcastInstance(int port) {
         Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
 
         config.getNetworkConfig().setPort(port).setPortAutoIncrement(false);
         JoinConfig join = config.getNetworkConfig().getJoin();

--- a/enterprise/hot-restart/src/main/java/JCacheRollingRestart.java
+++ b/enterprise/hot-restart/src/main/java/JCacheRollingRestart.java
@@ -12,9 +12,13 @@ import javax.cache.Cache;
 import javax.cache.spi.CachingProvider;
 import java.io.File;
 
-public class JCacheRollingRestart {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "---- LICENSE KEY ----";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class JCacheRollingRestart {
 
     private static final String HOT_RESTART_ROOT_DIR = System.getProperty("java.io.tmpdir")
             + File.separatorChar + "hazelcast-hot-restart";
@@ -46,7 +50,7 @@ public class JCacheRollingRestart {
 
     private static HazelcastInstance newHazelcastInstance(int port) {
         Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         config.getNetworkConfig().setPort(port).setPortAutoIncrement(false);
         JoinConfig join = config.getNetworkConfig().getJoin();
         join.getMulticastConfig().setEnabled(false);

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -52,5 +52,10 @@
             <artifactId>hazelcast-enterprise-all</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.hazelcast.samples</groupId>
+            <artifactId>helper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/enterprise/security-interceptor/src/main/java/MapSecurityInterceptor.java
+++ b/enterprise/security-interceptor/src/main/java/MapSecurityInterceptor.java
@@ -1,4 +1,5 @@
 import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.PermissionConfig;
 import com.hazelcast.config.SecurityConfig;
@@ -13,8 +14,13 @@ import com.hazelcast.util.EmptyStatement;
 
 import java.security.AccessControlException;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
- * SecurityInterceptor for filtering individual methods
+ * SecurityInterceptor for filtering individual methods.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class MapSecurityInterceptor {
 
@@ -30,12 +36,13 @@ public class MapSecurityInterceptor {
     private static final String DENIED_METHOD = "replace";
 
     public static void main(String[] args) {
-        // enter your licenceKey below
-        String licenceKey = "---- LICENCE KEY ----";
-        Config config = createConfig(licenceKey);
+        Config config = createConfig();
         Hazelcast.newHazelcastInstance(config);
 
-        HazelcastInstance client = HazelcastClient.newHazelcastClient();
+        ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
+        HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
         IMap<Object, Object> acceptedMap = client.getMap(ACCEPTED_MAP_NAME);
         IMap<Object, Object> deniedMap = client.getMap(DENIED_MAP_NAME);
 
@@ -68,12 +75,16 @@ public class MapSecurityInterceptor {
         } catch (Exception expected) {
             EmptyStatement.ignore(expected);
         }
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
     }
 
-    private static Config createConfig(String licenceKey) {
+    private static Config createConfig() {
         Config config = new Config();
-        config.setLicenseKey(licenceKey);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         config.setProperty("hazelcast.wait.seconds.before.join", "0");
+
         SecurityInterceptorConfig securityInterceptorConfig = new SecurityInterceptorConfig();
         securityInterceptorConfig.setClassName(MySecurityInterceptor.class.getName());
         SecurityConfig securityConfig = config.getSecurityConfig();

--- a/enterprise/socket-interceptor/src/main/java/SocketInterceptorClient.java
+++ b/enterprise/socket-interceptor/src/main/java/SocketInterceptorClient.java
@@ -9,24 +9,27 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
  * Socket interceptor used for authentication to clients
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class SocketInterceptorClient {
 
     public static void main(String[] args) {
-        // enter your licenceKey below
-        String licenceKey = "---- LICENCE KEY ----";
-        Config config = createConfig(licenceKey);
+        Config config = createConfig();
         Hazelcast.newHazelcastInstance(config);
 
         ClientConfig clientConfig = createClientConfig();
         HazelcastClient.newHazelcastClient(clientConfig);
     }
 
-    private static Config createConfig(String licenceKey) {
+    private static Config createConfig() {
         Config config = new Config();
-        config.setLicenseKey(licenceKey);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         config.setProperty("hazelcast.wait.seconds.before.join", "0");
 
         SocketInterceptorConfig interceptorConfig = new SocketInterceptorConfig();
@@ -38,13 +41,17 @@ public class SocketInterceptorClient {
 
     private static ClientConfig createClientConfig() {
         ClientConfig clientConfig = new ClientConfig();
+        clientConfig.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         SocketInterceptorConfig interceptorConfig = new SocketInterceptorConfig();
         interceptorConfig.setEnabled(true).setClassName(MySocketInterceptor.class.getName());
         clientConfig.getNetworkConfig().setSocketInterceptorConfig(interceptorConfig);
         return clientConfig;
     }
 
-    private static class MySocketInterceptor implements MemberSocketInterceptor {
+    /**
+     * This class needs to be public, so it can be accessed via Hazelcast.
+     */
+    public static class MySocketInterceptor implements MemberSocketInterceptor {
 
         public MySocketInterceptor() {
         }

--- a/enterprise/socket-interceptor/src/main/java/SocketInterceptorMember.java
+++ b/enterprise/socket-interceptor/src/main/java/SocketInterceptorMember.java
@@ -7,16 +7,19 @@ import java.io.IOException;
 import java.net.Socket;
 import java.util.Properties;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
 /**
- * Socket interceptor used for authentication to newly joining member
+ * Socket interceptor used for authentication to newly joining member.
+ *
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
  */
 public class SocketInterceptorMember {
 
     public static void main(String[] args) {
-        // enter your licenceKey below
-        String licenceKey = "---- LICENCE KEY ----";
-        Config config1 = createConfig(licenceKey);
-        Config config2 = createConfig(licenceKey);
+        Config config1 = createConfig();
+        Config config2 = createConfig();
 
         // each member will be given an id via SocketInterceptorConfig property
         config1.getNetworkConfig().getSocketInterceptorConfig().setProperty("member-id", "firstMember");
@@ -26,9 +29,9 @@ public class SocketInterceptorMember {
         Hazelcast.newHazelcastInstance(config2);
     }
 
-    private static Config createConfig(String licenceKey) {
+    private static Config createConfig() {
         Config config = new Config();
-        config.setLicenseKey(licenceKey);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         config.setProperty("hazelcast.wait.seconds.before.join", "0");
 
         SocketInterceptorConfig interceptorConfig = new SocketInterceptorConfig();

--- a/enterprise/wan-replication/src/main/java/com/hazelcast/cache/wanreplication/EnterpriseCacheWanReplicationClusterA.java
+++ b/enterprise/wan-replication/src/main/java/com/hazelcast/cache/wanreplication/EnterpriseCacheWanReplicationClusterA.java
@@ -27,9 +27,13 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Scanner;
 
-public class EnterpriseCacheWanReplicationClusterA {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "YOUR_LICENSE_KEY";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class EnterpriseCacheWanReplicationClusterA {
 
     private static HazelcastInstance clusterA;
 
@@ -107,7 +111,8 @@ public class EnterpriseCacheWanReplicationClusterA {
 
     private Config getConfigClusterA() {
         Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY).getGroupConfig().setName("clusterA").setPassword("clusterA-pass");
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+        config.getGroupConfig().setName("clusterA").setPassword("clusterA-pass");
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1:5701");
         config.setInstanceName("clusterA");
@@ -131,7 +136,7 @@ public class EnterpriseCacheWanReplicationClusterA {
 
         WanReplicationRef wanReplicationRef = new WanReplicationRef();
         wanReplicationRef.setName("AtoB");
-        config.setLicenseKey(LICENSE_KEY);
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
         wanReplicationRef.setMergePolicy(HigherHitsCacheMergePolicy.class.getName());
         wanReplicationRef.addFilter(SampleCacheWanEventFilter.class.getName());
         config.getCacheConfig("default").setWanReplicationRef(wanReplicationRef);

--- a/enterprise/wan-replication/src/main/java/com/hazelcast/cache/wanreplication/EnterpriseCacheWanReplicationClusterB.java
+++ b/enterprise/wan-replication/src/main/java/com/hazelcast/cache/wanreplication/EnterpriseCacheWanReplicationClusterB.java
@@ -18,9 +18,13 @@ import java.util.Properties;
 import java.util.Random;
 import java.util.Scanner;
 
-public class EnterpriseCacheWanReplicationClusterB {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "YOUR_LICENSE_KEY";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class EnterpriseCacheWanReplicationClusterB {
 
     private static HazelcastInstance clusterB;
 
@@ -95,8 +99,9 @@ public class EnterpriseCacheWanReplicationClusterB {
     }
 
     private Config getConfigClusterB() {
-        final Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY).getGroupConfig().setName("clusterB").setPassword("clusterB-pass");
+        Config config = new Config();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+        config.getGroupConfig().setName("clusterB").setPassword("clusterB-pass");
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1:5702");
         config.setInstanceName("clusterB");

--- a/enterprise/wan-replication/src/main/java/com/hazelcast/map/wanreplication/EnterpriseMapWanReplicationClusterA.java
+++ b/enterprise/wan-replication/src/main/java/com/hazelcast/map/wanreplication/EnterpriseMapWanReplicationClusterA.java
@@ -1,5 +1,6 @@
 package com.hazelcast.map.wanreplication;
 
+import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.IMap;
@@ -8,6 +9,12 @@ import java.io.IOException;
 import java.util.Random;
 import java.util.Scanner;
 
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
+
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
 public class EnterpriseMapWanReplicationClusterA {
 
     private static HazelcastInstance clusterA;
@@ -64,7 +71,10 @@ public class EnterpriseMapWanReplicationClusterA {
         }
     }
 
-    private static void initClusters() throws IOException {
-        clusterA = Hazelcast.newHazelcastInstance();
+    private static void initClusters() {
+        Config config = new Config();
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+
+        clusterA = Hazelcast.newHazelcastInstance(config);
     }
 }

--- a/enterprise/wan-replication/src/main/java/com/hazelcast/map/wanreplication/EnterpriseMapWanReplicationClusterB.java
+++ b/enterprise/wan-replication/src/main/java/com/hazelcast/map/wanreplication/EnterpriseMapWanReplicationClusterB.java
@@ -7,9 +7,13 @@ import com.hazelcast.core.IMap;
 
 import java.util.Scanner;
 
-public class EnterpriseMapWanReplicationClusterB {
+import static com.hazelcast.codesamples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
-    private static final String LICENSE_KEY = "YOUR_LICENSE_KEY";
+/**
+ * You have to set your Hazelcast Enterprise license key to make this code sample work.
+ * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
+ */
+public class EnterpriseMapWanReplicationClusterB {
 
     private static HazelcastInstance clusterB;
 
@@ -55,7 +59,8 @@ public class EnterpriseMapWanReplicationClusterB {
 
     private static Config getConfigClusterB() {
         Config config = new Config();
-        config.setLicenseKey(LICENSE_KEY).getGroupConfig().setName("clusterB").setPassword("clusterB-pass");
+        config.setLicenseKey(ENTERPRISE_LICENSE_KEY);
+        config.getGroupConfig().setName("clusterB").setPassword("clusterB-pass");
         config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(false);
         config.getNetworkConfig().getJoin().getTcpIpConfig().setEnabled(true).addMember("127.0.0.1:5702");
         return config;

--- a/enterprise/wan-replication/src/main/resources/hazelcast.xml
+++ b/enterprise/wan-replication/src/main/resources/hazelcast.xml
@@ -7,7 +7,6 @@
         <name>clusterA</name>
         <password>clusterA-pass</password>
     </group>
-    <license-key>YOUR_LICENSE_KEY</license-key>
 
     <network>
         <port>5701</port>

--- a/helper/README.md
+++ b/helper/README.md
@@ -1,0 +1,9 @@
+# Hazelcast code samples helper classes
+
+This module contains helper classes for the code samples.
+
+## Hazelcast Enterprise
+
+If you want to run Hazelcast Enterprise code samples, please have a look at LicenseUtils to learn
+* how to request a Hazelcast Enterprise trial key
+* how to configure the license key for the code samples

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -1,0 +1,21 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <artifactId>helper</artifactId>
+    <name>Hazelcast EE code sample helper classes</name>
+
+    <parent>
+        <artifactId>code-samples</artifactId>
+        <groupId>com.hazelcast.samples</groupId>
+        <version>0.1-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+</project>
+

--- a/helper/src/main/java/com/hazelcast/codesamples/helper/LicenseUtils.java
+++ b/helper/src/main/java/com/hazelcast/codesamples/helper/LicenseUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.codesamples.helper;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+/**
+ * Utils class to get the Hazelcast Enterprise license key for code samples.
+ *
+ * You can provide the license key via
+ * <ul>
+ * <li>the constant {@link LicenseUtils#ENTERPRISE_LICENSE_KEY}</li>
+ * <li>the file {@code .hazelcast-code-samples-license} in your home directory</li>
+ * <li>the system property {@code -Dhazelcast.enterprise.license.key=<YOUR_LICENSE_KEY_HERE>}</li>
+ * </ul>
+ *
+ * You can request a trial key at http://hazelcast.com/hazelcast-enterprise-trial
+ */
+public class LicenseUtils {
+
+    public static final String ENTERPRISE_LICENSE_KEY = initLicenseKey();
+
+    private static final int READ_BUFFER_SIZE = 8192;
+
+    private static String initLicenseKey() {
+        String licenseKey = System.getProperty("hazelcast.enterprise.license.key");
+        if (licenseKey != null) {
+            System.out.println("Hazelcast Enterprise license key was set via system properties");
+            return licenseKey.trim();
+        }
+
+        File licenseFile = new File(System.getProperty("user.home"), ".hazelcast-code-samples-license").getAbsoluteFile();
+        licenseKey = fileAsText(licenseFile);
+        if (licenseKey != null) {
+            System.out.println("Hazelcast Enterprise license key was set via license file");
+            return licenseKey.trim();
+        }
+
+        throw new RuntimeException("Hazelcast Enterprise license key was not configured!"
+                + " Please have a look at LicenseUtils for details.");
+    }
+
+    private static String fileAsText(File file) {
+        FileInputStream stream = null;
+        InputStreamReader streamReader = null;
+        BufferedReader reader = null;
+        try {
+            stream = new FileInputStream(file);
+            streamReader = new InputStreamReader(stream);
+            reader = new BufferedReader(streamReader);
+
+            StringBuilder builder = new StringBuilder();
+            char[] buffer = new char[READ_BUFFER_SIZE];
+            int read;
+            while ((read = reader.read(buffer, 0, buffer.length)) > 0) {
+                builder.append(buffer, 0, read);
+            }
+            return builder.toString();
+        } catch (IOException e) {
+            return null;
+        } finally {
+            closeQuietly(reader);
+            closeQuietly(streamReader);
+            closeQuietly(stream);
+        }
+    }
+
+    @SuppressWarnings("checkstyle:emptyblock")
+    private static void closeQuietly(Closeable closeable) {
+        if (closeable == null) {
+            return;
+        }
+        try {
+            closeable.close();
+        } catch (IOException ignore) {
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,7 @@
         <module>distributed-topic</module>
         <module>enterprise</module>
         <module>hazelcast-integration</module>
+        <module>helper</module>
         <module>jcache</module>
         <module>jmx</module>
         <module>learning-basics</module>


### PR DESCRIPTION
* Added `LicenseUtils` to ease settings of Hazelcast Enterprise License key in EE code samples
* Fixed settings of license key in some code samples (was not set at all or forgotten for e.g. clients)
* Added JavaDoc to all EE code samples to advise how to set the EE license key

This replaces the four different methods to set a license key, which we had before:
* via `static final String` field in the code sample
* via local variable in the code sample
* via system property `hazelcast.enterprise.license.key`
* via XML config file `<license-key>YOUR_LICENSE_KEY</license-key>`

The new approach is a bit more hidden, but you only have to set the license key once to make it work for all Enterprise code samples. You can still override a `static final String` field in `LicenseUtils` and you can still use the system property. The new method is to put your license key into a file in your home directory, which I think is the most convenient way.

JavaDoc example:
```
/**
 * You have to set your Hazelcast Enterprise license key to make this code sample work.
 * Please have a look at {@link com.hazelcast.codesamples.helper.LicenseUtils} for details.
 */
```