### PR TITLE
Added code samples for JCache OnHeap Near Cache

### DIFF
--- a/distributed-map/near-cache/src/main/java/com/hazelcast/examples/Article.java
+++ b/distributed-map/near-cache/src/main/java/com/hazelcast/examples/Article.java
@@ -2,8 +2,7 @@ package com.hazelcast.examples;
 
 import java.io.Serializable;
 
-@SuppressWarnings("unused")
-final class Article implements Serializable {
+public final class Article implements Serializable {
 
     private final String name;
 

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -37,6 +37,12 @@
             <artifactId>cache-api</artifactId>
             <version>${jsr107.api.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast.samples.distributed-map</groupId>
+            <artifactId>near-cache</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.hazelcast.samples</groupId>
             <artifactId>helper</artifactId>

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheUsage.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheUsage.java
@@ -5,16 +5,11 @@ import com.hazelcast.config.NearCacheConfig;
 
 import java.util.concurrent.TimeUnit;
 
-import static com.hazelcast.examples.helper.CommonUtils.sleepMillis;
-import static com.hazelcast.spi.properties.GroupProperty.CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS;
 import static java.lang.Boolean.getBoolean;
-import static java.lang.Integer.parseInt;
 
 public class ClientNearCacheUsage extends ClientNearCacheUsageSupport {
 
     private static final int RECORD_COUNT = 1000;
-    private static final int BATCH_FREQUENCY_MILLISECONDS
-            = parseInt(CACHE_INVALIDATION_MESSAGE_BATCH_FREQUENCY_SECONDS.getDefaultValue()) * 1000;
     private static final boolean VERBOSE = getBoolean("com.hazelcast.examples.jcache.nearcache.verbose");
 
     public void run() {
@@ -37,7 +32,7 @@ public class ClientNearCacheUsage extends ClientNearCacheUsageSupport {
         updateRecordsInCacheOnClient1(clientCache1);
 
         // wait a little for invalidation events
-        sleepMillis(BATCH_FREQUENCY_MILLISECONDS + 5000);
+        waitForInvalidationEvents();
 
         // get invalidated records from remote cache on client-2
         getInvalidatedRecordsFromNearCacheOnClient2(clientCache2);

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithEviction.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithEviction.java
@@ -1,0 +1,54 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+public class ClientNearCacheWithEviction extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT));
+
+        ICache<Integer, Article> cache = createCacheWithNearCache(nearCacheConfig);
+
+        for (int i = 1; i <= RECORD_COUNT; i++) {
+            cache.put(i, new Article("foo" + i));
+        }
+        printNearCacheStats(cache, "The put(1..100, article) calls have no effect on the empty Near Cache");
+
+        for (int i = 1; i <= RECORD_COUNT; i++) {
+            cache.get(i);
+        }
+        printNearCacheStats(cache, "The first get(1..100) calls populate the Near Cache");
+
+        for (int i = 1; i <= RECORD_COUNT; i++) {
+            cache.get(i);
+        }
+        printNearCacheStats(cache, "The second get(1..100) calls are served from the Near Cache");
+
+        cache.put(101, new Article("foo101"));
+        printNearCacheStats(cache, "The put(101, article) call has no effect on the populated Near Cache");
+
+        cache.get(101);
+        printNearCacheStats(cache, "The first get(101) call triggers the eviction and population of the Near Cache");
+
+        cache.get(101);
+        printNearCacheStats(cache, "The second get(101) call is served from the Near Cache");
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithEviction clientNearCacheUsage = new ClientNearCacheWithEviction();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithInvalidation.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithInvalidation.java
@@ -1,0 +1,50 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+import static com.hazelcast.examples.helper.HazelcastUtils.generateKeyOwnedBy;
+
+public class ClientNearCacheWithInvalidation extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setInvalidateOnChange(true);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<String, Article> cache1 = createCacheWithNearCache(nearCacheConfig);
+        ICache<String, Article> cache2 = createCacheWithNearCache(nearCacheConfig);
+
+        String key = generateKeyOwnedBy(getServerInstance());
+
+        cache2.put(key, new Article("foo"));
+        printNearCacheStats(cache1, "The cache2.put(key, new Article(\"foo\")) call has no effect on the Near Cache of cache1");
+
+        cache1.get(key);
+        printNearCacheStats(cache1, "The first cache1.get(key) call populates the Near Cache of cache1");
+
+        cache2.put(key, new Article("bar"));
+        printNearCacheStats(cache1, "The cache2.put(key, new Article(\"bar\") call will invalidate the Near Cache on cache1");
+
+        waitForInvalidationEvents();
+        printNearCacheStats(cache1, "The Near Cache of cache1 is empty after the invalidation event has been processed");
+
+        cache1.get(key);
+        printNearCacheStats(cache1, "The next cache1.get(key) call populates the Near Cache again");
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithInvalidation clientNearCacheUsage = new ClientNearCacheWithInvalidation();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithLocalUpdatePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithLocalUpdatePolicy.java
@@ -1,0 +1,58 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+import static com.hazelcast.examples.helper.HazelcastUtils.generateKeyOwnedBy;
+
+public class ClientNearCacheWithLocalUpdatePolicy extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setLocalUpdatePolicy(NearCacheConfig.LocalUpdatePolicy.CACHE);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<String, Article> cache1 = createCacheWithNearCache(nearCacheConfig);
+        ICache<String, Article> cache2 = createCacheWithNearCache(nearCacheConfig);
+
+        String key = generateKeyOwnedBy(getServerInstance());
+
+        cache1.put(key, new Article("foo"));
+        printNearCacheStats(cache1, "The cache1.put(key, new Article(\"foo\")) call will populate the Near Cache of cache1, ...");
+        printNearCacheStats(cache2, "..., but has no effect on the Near Cache of cache2");
+
+        cache1.get(key);
+        printNearCacheStats(cache1, "The first cache1.get(key) call be served by the Near Cache of cache1");
+
+        cache2.get(key);
+        printNearCacheStats(cache2, "The first cache2.get(key) call populates the Near Cache of cache2");
+
+        cache1.put(key, new Article("bar"));
+        printNearCacheStats(cache1, "The cache1.put(key, new Article(\"bar\") call will update the Near Cache of cache1, ...");
+        printNearCacheStats(cache2, "..., but has no effect on the Near Cache of cache2");
+
+        Article article1 = cache1.get(key);
+        printNearCacheStats(cache1, "The second cache1.get(key) call will be served by the Near Cache of cache1");
+
+        Article article2 = cache2.get(key);
+        printNearCacheStats(cache2, "The second cache2.get(key) call will be served by the Near Cache of cache2");
+
+        System.out.printf("The retrieved articles are not the same: %s vs. %s%n", article1.getName(), article2.getName());
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithLocalUpdatePolicy clientNearCacheUsage = new ClientNearCacheWithLocalUpdatePolicy();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMaxIdle.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMaxIdle.java
@@ -1,0 +1,54 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+import static com.hazelcast.examples.helper.CommonUtils.sleepMillis;
+
+public class ClientNearCacheWithMaxIdle extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+    private static final int MAX_IDLE_SECONDS = 1;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setCacheLocalEntries(true);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setMaxIdleSeconds(MAX_IDLE_SECONDS);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<Integer, Article> cache = createCacheWithNearCache(nearCacheConfig);
+
+        cache.put(1, new Article("foo"));
+        printNearCacheStats(cache, "The put(1, article) call has no effect on the empty Near Cache");
+
+        cache.get(1);
+        printNearCacheStats(cache, "The first get(1) call populates the Near Cache");
+
+        // with this short sleep time, the Near Cache entry should not expire
+        for (int i = 0; i < 20; i++) {
+            cache.get(1);
+            sleepMillis(100);
+        }
+        printNearCacheStats(cache, "We have called get(1) every 100 ms, so the Near cache entry could not expire");
+
+        waitForExpirationTask(MAX_IDLE_SECONDS);
+        printNearCacheStats(cache, "We've waited for max-idle-seconds, so the Near Cache entry is expired.");
+
+        cache.get(1);
+        printNearCacheStats(cache, "The next get(1) call is fetching the value again from the cache");
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithMaxIdle clientNearCacheUsage = new ClientNearCacheWithMaxIdle();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMemoryFormatBinary.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMemoryFormatBinary.java
@@ -1,0 +1,46 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+public class ClientNearCacheWithMemoryFormatBinary extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.BINARY);
+        nearCacheConfig.setCacheLocalEntries(true);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<Integer, Article> cache = createCacheWithNearCache(nearCacheConfig);
+
+        Article article = new Article("foo");
+        cache.put(1, article);
+
+        // the first get() will populate the Near Cache
+        Article firstGet = cache.get(1);
+        // the second and third get() will be served from the Near Cache
+        Article secondGet = cache.get(1);
+        Article thirdGet = cache.get(1);
+
+        printNearCacheStats(cache);
+
+        System.out.println("Since we use in-memory format BINARY, the article instances from the Near Cache will be different.");
+        System.out.println("Compare first and second article instance: " + (firstGet == secondGet));
+        System.out.println("Compare second and third article instance: " + (secondGet == thirdGet));
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithMemoryFormatBinary clientNearCacheUsage = new ClientNearCacheWithMemoryFormatBinary();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMemoryFormatObject.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithMemoryFormatObject.java
@@ -1,0 +1,46 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+public class ClientNearCacheWithMemoryFormatObject extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setCacheLocalEntries(true);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<Integer, Article> cache = createCacheWithNearCache(nearCacheConfig);
+
+        Article article = new Article("foo");
+        cache.put(1, article);
+
+        // the first get() will populate the Near Cache
+        Article firstGet = cache.get(1);
+        // the second and third get() will be served from the Near Cache
+        Article secondGet = cache.get(1);
+        Article thirdGet = cache.get(1);
+
+        printNearCacheStats(cache);
+
+        System.out.println("Since we use in-memory format BINARY, the article instances from the Near Cache will be different.");
+        System.out.println("Compare first and second article instance: " + (firstGet == secondGet));
+        System.out.println("Compare second and third article instance: " + (secondGet == thirdGet));
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithMemoryFormatObject clientNearCacheUsage = new ClientNearCacheWithMemoryFormatObject();
+        clientNearCacheUsage.run();
+    }
+}

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithTTL.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithTTL.java
@@ -1,0 +1,45 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+
+public class ClientNearCacheWithTTL extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+    private static final int TIME_TO_LIVE_SECONDS = 1;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig = createNearCacheConfig();
+        nearCacheConfig.setInMemoryFormat(InMemoryFormat.OBJECT);
+        nearCacheConfig.setCacheLocalEntries(true);
+        nearCacheConfig.setInvalidateOnChange(false);
+        nearCacheConfig.setTimeToLiveSeconds(TIME_TO_LIVE_SECONDS);
+        nearCacheConfig.setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<Integer, Article> cache = createCacheWithNearCache(nearCacheConfig);
+
+        cache.put(1, new Article("foo"));
+        printNearCacheStats(cache, "The put(1, article) call has no effect on the empty Near Cache");
+
+        cache.get(1);
+        printNearCacheStats(cache, "The first get(1) call populates the Near Cache");
+
+        waitForExpirationTask(TIME_TO_LIVE_SECONDS);
+        printNearCacheStats(cache, "We've waited for the time-to-live-seconds, so the Near Cache entry is expired.");
+
+        cache.get(1);
+        printNearCacheStats(cache, "The next get(1) call is fetching the value again from the cache");
+
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithTTL clientNearCacheUsage = new ClientNearCacheWithTTL();
+        clientNearCacheUsage.run();
+    }
+}


### PR DESCRIPTION
Adapted the new `IMap` client Near Cache code samples for `JCache`.

This one also adds a code sample for the `local-update-policy` configuration, which is just supported by `JCache` at the moment.