### PR TITLE
Fix sample

### DIFF
--- a/hazelcast-integration/springboot-caching-jcache/src/main/java/com/hazelcast/springboot/caching/BootifulClient.java
+++ b/hazelcast-integration/springboot-caching-jcache/src/main/java/com/hazelcast/springboot/caching/BootifulClient.java
@@ -20,7 +20,6 @@ package com.hazelcast.springboot.caching;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
@@ -40,9 +39,7 @@ import static java.lang.System.out;
  * @author Viktor Gamov on 12/26/15.
  *         Twitter: @gamussa
  */
-@SpringBootApplication(scanBasePackages = "com.hazelcast.springboot.caching.BootifulClient")
-// disable Hazelcast Auto Configuration, and use JCache configuration for the client example
-@EnableAutoConfiguration(exclude = {HazelcastAutoConfiguration.class})
+@SpringBootApplication(exclude = HazelcastAutoConfiguration.class)
 @EnableCaching
 @SuppressWarnings("unused")
 public class BootifulClient {

--- a/hazelcast-integration/springboot-caching-jcache/src/main/java/com/hazelcast/springboot/caching/BootifulMember.java
+++ b/hazelcast-integration/springboot-caching-jcache/src/main/java/com/hazelcast/springboot/caching/BootifulMember.java
@@ -18,9 +18,7 @@
 
 package com.hazelcast.springboot.caching;
 
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.hazelcast.HazelcastAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cache.annotation.EnableCaching;
 
@@ -30,11 +28,7 @@ import org.springframework.cache.annotation.EnableCaching;
  * @author Viktor Gamov on 12/26/15.
  *         Twitter: @gamussa
  */
-@SpringBootApplication(scanBasePackages = "com.hazelcast.springboot.caching.BootifulMember")
-@EnableAutoConfiguration(exclude = {
-        // disable Hazelcast Auto Configuration, and use JCache configuration for the member example
-        HazelcastAutoConfiguration.class
-})
+@SpringBootApplication
 @EnableCaching
 public class BootifulMember {
     public static void main(String[] args) {

--- a/hazelcast-integration/springboot-caching-jcache/src/main/resources/application-client.properties
+++ b/hazelcast-integration/springboot-caching-jcache/src/main/resources/application-client.properties
@@ -15,5 +15,4 @@
 #  limitations under the License.
 #
 #
-spring.cache.type=jcache
 spring.cache.jcache.provider=com.hazelcast.client.cache.impl.HazelcastClientCachingProvider

--- a/hazelcast-integration/springboot-caching-jcache/src/main/resources/application-member.properties
+++ b/hazelcast-integration/springboot-caching-jcache/src/main/resources/application-member.properties
@@ -15,5 +15,6 @@
 #  limitations under the License.
 #
 #
-spring.cache.type=jcache
 spring.cache.jcache.provider=com.hazelcast.cache.impl.HazelcastServerCachingProvider
+spring.cache.jcache.config=hazelcast.xml
+spring.hazelcast.config=hazelcast.xml

--- a/hazelcast-integration/springboot-caching-jcache/src/main/resources/hazelcast.xml
+++ b/hazelcast-integration/springboot-caching-jcache/src/main/resources/hazelcast.xml
@@ -22,6 +22,8 @@
         xmlns="http://www.hazelcast.com/schema/config"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+	<instance-name>my-cluster</instance-name>
+
     <group>
         <name>bootifulcluster</name>
         <password>bootiful-pass</password>


### PR DESCRIPTION
This commit tries to clarify the sample with regards to some discussion
on the Spring Boot issue tracker, in particular:

https://github.com/spring-projects/spring-boot/issues/8275

To be able to reuse an `HazelcastInstance` in server mode, the location
of the configuration file should be set in both auto-configuration
unfortunately: there is currently now way to reuse an instance that was
loaded via the default configuration. See the following issue:

https://github.com/hazelcast/hazelcast/issues/10007

In a client scenario, the only way is to effectively disable the
auto-configuration which annoys me a lot. Probably Spring Boot should
back off automatically in such a scenario but we need a way to reliably
figure this out.

Also, I wasn't aware that Hazelcast provides different `CachingProvider`
that are looking for different things. IMO, there is a gap in the
caching support in Spring Boot about it and I'd be more than happy to
improve it as long as I don't need to resort to Hazelcast specific API
inside the JCache auto-configuration