### PR TITLE
docker-compose code sample for ldap&mancenter

### DIFF
--- a/hazelcast-integration/ldap-docker/docker-compose.yaml
+++ b/hazelcast-integration/ldap-docker/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '2.1'
+services:
+ openldap:
+    image: bilaldemirci/openldap
+    ports:
+     - 389:389
+ management-center:
+    image: hazelcast/management-center
+    volumes: 
+     - ../ldap-docker/security.properties:/data/security.properties
+     - ../ldap-docker/ldap.properties:/data/ldap.properties
+    depends_on:
+     - openldap 
+    ports:
+     - 8080:8080
+    links:
+     - "openldap:ldapIP"

--- a/hazelcast-integration/ldap-docker/ldap.properties
+++ b/hazelcast-integration/ldap-docker/ldap.properties
@@ -1,0 +1,15 @@
+url=ldap\://ldapIP\:389
+baseDn=dc\=hazelcast,dc\=org
+domain=
+username=cn\=Emre Aydin,ou\=Users,dc\=hazelcast,dc\=org
+userGroup=theUserGroup
+userSearchFilter=uid\={0}
+startTls=false
+type=LDAP
+groupDn=ou\=UserGroups
+metricsOnlyGroup=theMetricsonlyGroup
+userDn=ou\=Users
+groupSearchFilter=uniqueMember\={0}
+password=password
+readonlyUserGroup=theReadonlyGroup
+adminGroup=theAdminGroup

--- a/hazelcast-integration/ldap-docker/openldap/Dockerfile
+++ b/hazelcast-integration/ldap-docker/openldap/Dockerfile
@@ -1,0 +1,19 @@
+FROM  ubuntu:trusty
+
+RUN apt-get update && \
+	echo 'slapd/root_password password password' | debconf-set-selections &&\
+    echo 'slapd/root_password_again password password' | debconf-set-selections && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y slapd ldap-utils &&\
+	rm -rf /var/lib/apt/lists/*
+
+ADD files /ldap
+
+RUN service slapd start ;\
+    cd /ldap &&\
+	ldapadd -Y EXTERNAL -H ldapi:/// -f back.ldif &&\
+    ldapadd -x -D cn=admin,dc=hazelcast,dc=org -w password -c -f groups.ldif &&\
+    ldapadd -x -D cn=admin,dc=hazelcast,dc=org -w password -c -f users.ldif
+
+EXPOSE 389
+
+CMD slapd -h 'ldap:/// ldapi:///' -g openldap -u openldap -F /etc/ldap/slapd.d -d stats

--- a/hazelcast-integration/ldap-docker/openldap/files/back.ldif
+++ b/hazelcast-integration/ldap-docker/openldap/files/back.ldif
@@ -1,0 +1,22 @@
+version: 1
+changeType: add
+dn: olcDatabase=hdb,cn=config
+objectClass: olcDatabaseConfig
+objectClass: olcHdbConfig
+olcDatabase: {2}hdb
+olcDbDirectory: /var/lib/ldap
+olcSuffix: dc=hazelcast,dc=org
+olcAccess: {0}to attrs=userPassword,shadowLastChange by self write by anonymous auth by dn="cn=admin,dc=hazelcast,dc=org" write by * none
+olcAccess: {1}to dn.base="" by * read
+olcAccess: {2}to * by self write by dn="cn=admin,dc=hazelcast,dc=org" write by * read
+olcLastMod: TRUE
+olcRootDN: cn=admin,dc=hazelcast,dc=org
+olcRootPW: password
+olcDbCheckpoint: 512 30
+olcDbConfig: {0}set_cachesize 0 2097152 0
+olcDbConfig: {1}set_lk_max_objects 1500
+olcDbConfig: {2}set_lk_max_locks 1500
+olcDbConfig: {3}set_lk_max_lockers 1500
+olcDbIndex: objectClass eq
+olcDbIndex: uid eq
+olcDbIndex: uniqueMember eq

--- a/hazelcast-integration/ldap-docker/openldap/files/groups.ldif
+++ b/hazelcast-integration/ldap-docker/openldap/files/groups.ldif
@@ -1,0 +1,42 @@
+dn: dc=hazelcast,dc=org
+dc: hazelcast
+objectClass: dcObject
+objectClass: organizationalUnit
+ou: hazelcast
+
+dn: ou=UserGroups,dc=hazelcast,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: UserGroups
+
+dn: ou=Users,dc=hazelcast,dc=org
+objectClass: organizationalUnit
+objectClass: top
+ou: Users
+
+dn: cn=theReadonlyGroup,ou=UserGroups,dc=hazelcast,dc=org
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: theReadonlyGroup
+uniqueMember: cn=Hasan Celik,ou=Users,dc=hazelcast,dc=org
+uniqueMember: cn=Bilal Yasar,ou=Users,dc=hazelcast,dc=org
+
+dn: cn=theMetricsonlyGroup,ou=UserGroups,dc=hazelcast,dc=org
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: theMetricsonlyGroup
+uniqueMember: cn=Metric Guy,ou=Users,dc=hazelcast,dc=org
+
+dn: cn=theUserGroup,ou=UserGroups,dc=hazelcast,dc=org
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: theUseronlyGroup
+uniqueMember: cn=Mesut Celik,ou=Users,dc=hazelcast,dc=org
+uniqueMember: cn=Emrah Kocaman,ou=Users,dc=hazelcast,dc=org
+
+dn: cn=theAdminGroup,ou=UserGroups,dc=hazelcast,dc=org
+objectClass: top
+objectClass: groupOfUniqueNames
+cn: theAdminGroup
+uniqueMember: cn=Emre Aydin,ou=Users,dc=hazelcast,dc=org
+uniqueMember: cn=Mesut Celik,ou=Users,dc=hazelcast,dc=org

--- a/hazelcast-integration/ldap-docker/openldap/files/users.ldif
+++ b/hazelcast-integration/ldap-docker/openldap/files/users.ldif
@@ -1,0 +1,74 @@
+dn: cn=Emre Aydin,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Emre Aydin
+sn: Emre
+uid: emre
+userpassword: password
+mail: emre@hazelcast.com
+
+dn: cn=Mesut Celik,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Mesut Celik
+sn: Mesut
+uid: mesut
+userpassword: password
+mail: mesut@hazelcast.com
+
+dn: cn=Emrah Kocaman,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Emrah Kocaman
+sn: Emrah
+uid: emrah
+userpassword: password
+mail: emrah@hazelcast.com
+
+dn: cn=Hasan Celik,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Hasan Celik
+sn: Hasan
+uid: hasan
+userpassword: password
+mail: hasan@hazelcast.com
+
+dn: cn=Bilal Yasar,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Bilal Yasar
+sn: Bilal
+uid: bilal
+userpassword: password
+mail: bilal@hazelcast.com
+
+dn: cn=Guest user,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Guest user
+sn: Guest
+uid: guest
+userpassword: password
+
+dn: cn=Metric Guy,ou=Users,dc=hazelcast,dc=org
+objectclass: person
+objectclass: inetOrgPerson
+objectclass: organizationalPerson
+objectclass: top
+cn: Metric Guy
+sn: MetricGuy
+uid: metricguy
+userpassword: password

--- a/hazelcast-integration/ldap-docker/security.properties
+++ b/hazelcast-integration/ldap-docker/security.properties
@@ -1,0 +1,1 @@
+currentProvider=LDAP


### PR DESCRIPTION
In this PR, we created a sample docker application for authenticating with ldap on hazelcast management center. 

You can run the example by running this command;

`docker-compose up`

This will be create two container with an OpenLDAP database sample and a management center.

Open a browser and enter;
 
`http://localhost:8080/mancenter`

And login with this credentials;

Username: `emre`
Password: `password`