### PR TITLE
Fixed CheckStyle issues

### DIFF
--- a/clients/client-statistics/pom.xml
+++ b/clients/client-statistics/pom.xml
@@ -11,4 +11,10 @@
 
     <artifactId>client-statistics</artifactId>
 
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
 </project>

--- a/clients/usercodedeployment/pom.xml
+++ b/clients/usercodedeployment/pom.xml
@@ -12,10 +12,15 @@
     <groupId>com.hazelcast.samples</groupId>
     <artifactId>usercodedeployment</artifactId>
     <packaging>pom</packaging>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <modules>
         <module>usercodedeployment-member</module>
         <module>usercodedeployment-client</module>
     </modules>
-
-
 </project>

--- a/clients/usercodedeployment/usercodedeployment-client/pom.xml
+++ b/clients/usercodedeployment/usercodedeployment-client/pom.xml
@@ -9,8 +9,13 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.hazelcast.samples</groupId>
     <artifactId>usercodedeployment-client</artifactId>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 
     <build>
         <plugins>
@@ -39,5 +44,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
 </project>

--- a/clients/usercodedeployment/usercodedeployment-client/src/main/java/Client.java
+++ b/clients/usercodedeployment/usercodedeployment-client/src/main/java/Client.java
@@ -27,7 +27,5 @@ public class Client {
         for (int i = 0; i < keyCount; i++) {
             System.out.println(map.get(i));
         }
-
     }
-
 }

--- a/clients/usercodedeployment/usercodedeployment-member/pom.xml
+++ b/clients/usercodedeployment/usercodedeployment-member/pom.xml
@@ -9,8 +9,11 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.hazelcast.samples</groupId>
-    <artifactId>usercodedeploment-member</artifactId>
+    <artifactId>usercodedeployment-member</artifactId>
 
-
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
 </project>

--- a/hazelcast-integration/docker-compose/pom.xml
+++ b/hazelcast-integration/docker-compose/pom.xml
@@ -17,8 +17,13 @@
     <description>Example application (client) and docker-compose</description>
 
     <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
         <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
     </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -63,5 +68,4 @@
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/hazelcast-integration/docker-compose/src/main/java/MyClient.java
+++ b/hazelcast-integration/docker-compose/src/main/java/MyClient.java
@@ -8,9 +8,10 @@ import com.hazelcast.core.IQueue;
  * Simple Hazelcast client application
  *
  * @author Viktor Gamov on 5/23/17.
- *         Twitter: @gamussa
+ * Twitter: @gamussa
  */
 public class MyClient {
+
     public static void main(String[] args) throws InterruptedException {
 
         ClientConfig clientConfig = new XmlClientConfigBuilder().build();

--- a/hazelcast-integration/docker-compose/src/main/resources/hazelcast.xml
+++ b/hazelcast-integration/docker-compose/src/main/resources/hazelcast.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast
-    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.8.xsd"
-    xmlns="http://www.hazelcast.com/schema/config"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+        xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-3.8.xsd"
+        xmlns="http://www.hazelcast.com/schema/config"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
     <!-- properties will be passed via -D... JAVA_OPTS -->
     <!-- see hazelcast.yml -->


### PR DESCRIPTION
Some modules where missing the `main.basedir` property, so CheckStyle could not find its configuration files. After fixing that, some classes had to be fixed.