### PR TITLE
Avoid HazelcastInstanceNotActiveException stacktrace poping into the console in clients/basic

### DIFF
--- a/clients/basic/src/main/java/Member.java
+++ b/clients/basic/src/main/java/Member.java
@@ -1,5 +1,6 @@
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
 
 import java.util.concurrent.BlockingQueue;
 
@@ -10,8 +11,12 @@ public class Member {
         System.out.println("Hazelcast Member instance is running!");
 
         BlockingQueue<String> queue = hz.getQueue("queue");
-        for (; ; ) {
-            System.out.println(queue.take());
+        try {
+            for (; ; ) {
+                System.out.println(queue.take());
+            }
+        } catch (HazelcastInstanceNotActiveException e) {
+            System.err.println("Unable to take from the queue. Hazelcast Member is probably going down!");
         }
     }
 }


### PR DESCRIPTION
This change just improves user experience.

Instead of stacktrace in the console this commit adds a new error message to be displayed when Member is shutting down and `HazelcastInstanceNotActiveException` is thrown for `queue.take()`.

Original exception is:
```
Exception in thread "main" com.hazelcast.core.HazelcastInstanceNotActiveException: Hazelcast instance is not active!
	at com.hazelcast.spi.impl.operationparker.impl.OperationParkerImpl.shutdown(OperationParkerImpl.java:277)
	at com.hazelcast.spi.impl.NodeEngineImpl.shutdown(NodeEngineImpl.java:522)
	at com.hazelcast.instance.Node.shutdownServices(Node.java:473)
	at com.hazelcast.instance.Node.shutdown(Node.java:447)
	at com.hazelcast.instance.LifecycleServiceImpl.shutdown(LifecycleServiceImpl.java:98)
	at com.hazelcast.instance.LifecycleServiceImpl.terminate(LifecycleServiceImpl.java:86)
	at com.hazelcast.instance.Node$NodeShutdownHookThread.run(Node.java:630)
	at ------ submitted from ------.(Unknown Source)
	at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.resolve(InvocationFuture.java:127)
	at com.hazelcast.spi.impl.operationservice.impl.InvocationFuture.resolveAndThrowIfException(InvocationFuture.java:79)
	at com.hazelcast.spi.impl.AbstractInvocationFuture.get(AbstractInvocationFuture.java:155)
	at com.hazelcast.collection.impl.queue.QueueProxySupport.invokeAndGet(QueueProxySupport.java:177)
	at com.hazelcast.collection.impl.queue.QueueProxySupport.pollInternal(QueueProxySupport.java:124)
	at com.hazelcast.collection.impl.queue.QueueProxyImpl.poll(QueueProxyImpl.java:88)
	at com.hazelcast.collection.impl.queue.QueueProxyImpl.take(QueueProxyImpl.java:82)
	at Member.main(Member.java:14)
```