### PR TITLE
Use hazelcast.version from parent POM, don't override it in child modules

### DIFF
--- a/hazelcast-integration/springboot-eureka-partition-groups/pom.xml
+++ b/hazelcast-integration/springboot-eureka-partition-groups/pom.xml
@@ -20,7 +20,6 @@
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <hazelcast.version>3.8</hazelcast.version>
         <java.version>1.8</java.version>
         <spring-boot.version>1.5.2.RELEASE</spring-boot.version>
         <spring-cloud.version>Camden.SR5</spring-cloud.version>

--- a/near-cache/fraud-detection/pom.xml
+++ b/near-cache/fraud-detection/pom.xml
@@ -20,7 +20,6 @@
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <hazelcast.version>3.9-SNAPSHOT</hazelcast.version>
         <java.version>8</java.version>
         <spring-boot.version>1.5.7.RELEASE</spring-boot.version>
     </properties>


### PR DESCRIPTION
This commit removes hardcoded `hazelcast.version` property from 2 samples. The value from parent POM should be used instead.