### PR TITLE
Added code example for Near Cache with serialized keys

### DIFF
--- a/clients/client-near-cache/src/main/java/com/hazelcast/examples/ClientNearCacheWithSerializedKeys.java
+++ b/clients/client-near-cache/src/main/java/com/hazelcast/examples/ClientNearCacheWithSerializedKeys.java
@@ -1,0 +1,45 @@
+package com.hazelcast.examples;
+
+import com.hazelcast.client.config.ClientConfig;
+import com.hazelcast.client.impl.HazelcastClientProxy;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+public class ClientNearCacheWithSerializedKeys extends NearCacheClientSupport {
+
+    public static void main(String[] args) {
+        HazelcastInstance hz = initCluster();
+        IMap<ArticleKey, Article> map1 = hz.getMap("articlesObject");
+        IMap<ArticleKey, Article> map2 = hz.getMap("articlesSerializedKeys");
+
+        ClientConfig config = ((HazelcastClientProxy) hz).getClientConfig();
+        NearCacheConfig nearCacheConfig1 = config.getNearCacheConfig("articlesObject");
+        NearCacheConfig nearCacheConfig2 = config.getNearCacheConfig("articlesSerializedKeys");
+
+        System.out.println("Near Cache of map 1 uses serialized keys: " + nearCacheConfig1.isSerializeKeys());
+        System.out.println("Near Cache of map 2 uses serialized keys: " + nearCacheConfig2.isSerializeKeys());
+
+        ArticleKey key1 = new ArticleKey(1);
+        ArticleKey key2 = new ArticleKey(2);
+        Article article = new Article("foo");
+
+        System.out.println("\nPopulate the data structure (both keys are serialized, since it's a remote operation)...");
+        map1.put(key1, article);
+        map2.put(key2, article);
+
+        System.out.println("\nThe first get() will populate the Near Cache (again a remote operation for both keys)...");
+        map1.get(key1);
+        map2.get(key2);
+
+        System.out.println("\nThe second get() will be served from the Near Cache (key 2 is serialized for the local lookup)...");
+        map1.get(key1);
+        map2.get(key2);
+
+        System.out.println("\nThe Near Cache statistics are the same (the key serialization is transparent to the user)...");
+        System.out.println("Near Cache from map 1: " + map1.getLocalMapStats().getNearCacheStats());
+        System.out.println("Near Cache from map 2: " + map2.getLocalMapStats().getNearCacheStats());
+
+        shutdown();
+    }
+}

--- a/clients/client-near-cache/src/main/resources/hazelcast-client.xml
+++ b/clients/client-near-cache/src/main/resources/hazelcast-client.xml
@@ -20,6 +20,13 @@
                                http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.9.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
+    <near-cache name="articlesSerializedKeys">
+        <in-memory-format>OBJECT</in-memory-format>
+        <serialize-keys>true</serialize-keys>
+        <invalidate-on-change>false</invalidate-on-change>
+        <eviction eviction-policy="NONE" max-size-policy="ENTRY_COUNT"/>
+    </near-cache>
+    
     <near-cache name="articlesObject">
         <in-memory-format>OBJECT</in-memory-format>
         <invalidate-on-change>false</invalidate-on-change>

--- a/distributed-map/nearcache/src/main/java/com/hazelcast/examples/ArticleKey.java
+++ b/distributed-map/nearcache/src/main/java/com/hazelcast/examples/ArticleKey.java
@@ -1,0 +1,28 @@
+package com.hazelcast.examples;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.DataSerializable;
+
+import java.io.IOException;
+
+public class ArticleKey implements DataSerializable {
+
+    private int key;
+
+    public ArticleKey(int key) {
+        this.key = key;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) throws IOException {
+        System.out.println("Called writeData() for key " + key);
+        out.writeInt(key);
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) throws IOException {
+        System.out.println("Called readData() for key " + key);
+        key = in.readInt();
+    }
+}

--- a/distributed-map/nearcache/src/main/java/com/hazelcast/examples/NearCacheSupport.java
+++ b/distributed-map/nearcache/src/main/java/com/hazelcast/examples/NearCacheSupport.java
@@ -37,7 +37,7 @@ abstract class NearCacheSupport {
         Hazelcast.shutdownAll();
     }
 
-    protected static void printNearCacheStats(IMap<Integer, Article> map) {
+    protected static void printNearCacheStats(IMap<?, Article> map) {
         NearCacheStats stats = map.getLocalMapStats().getNearCacheStats();
 
         System.out.printf("The Near Cache contains %d entries.%n", stats.getOwnedEntryCount());

--- a/distributed-map/nearcache/src/main/java/com/hazelcast/examples/NearCacheWithSerializedKeys.java
+++ b/distributed-map/nearcache/src/main/java/com/hazelcast/examples/NearCacheWithSerializedKeys.java
@@ -1,0 +1,44 @@
+package com.hazelcast.examples;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+
+public class NearCacheWithSerializedKeys extends NearCacheSupport {
+
+    public static void main(String[] args) {
+        HazelcastInstance hz = initCluster();
+        IMap<ArticleKey, Article> map1 = hz.getMap("articlesObject");
+        IMap<ArticleKey, Article> map2 = hz.getMap("articlesSerializedKeys");
+
+        Config config = hz.getConfig();
+        NearCacheConfig nearCacheConfig1 = config.getMapConfig("articlesObject").getNearCacheConfig();
+        NearCacheConfig nearCacheConfig2 = config.getMapConfig("articlesSerializedKeys").getNearCacheConfig();
+
+        System.out.println("Near Cache of map 1 uses serialized keys: " + nearCacheConfig1.isSerializeKeys());
+        System.out.println("Near Cache of map 2 uses serialized keys: " + nearCacheConfig2.isSerializeKeys());
+
+        ArticleKey key1 = new ArticleKey(1);
+        ArticleKey key2 = new ArticleKey(2);
+        Article article = new Article("foo");
+
+        System.out.println("\nPopulate the data structure (both keys are serialized, since it's a remote operation)...");
+        map1.put(key1, article);
+        map2.put(key2, article);
+
+        System.out.println("\nThe first get() will populate the Near Cache (again a remote operation for both keys)...");
+        map1.get(key1);
+        map2.get(key2);
+
+        System.out.println("\nThe second get() will be served from the Near Cache (key 2 is serialized for the local lookup)...");
+        map1.get(key1);
+        map2.get(key2);
+
+        System.out.println("\nThe Near Cache statistics are the same (the key serialization is transparent to the user)...");
+        System.out.println("Near Cache from map 1: " + map1.getLocalMapStats().getNearCacheStats());
+        System.out.println("Near Cache from map 2: " + map2.getLocalMapStats().getNearCacheStats());
+
+        shutdown();
+    }
+}

--- a/distributed-map/nearcache/src/main/resources/hazelcast.xml
+++ b/distributed-map/nearcache/src/main/resources/hazelcast.xml
@@ -3,6 +3,16 @@
                                http://www.hazelcast.com/schema/config/hazelcast-config-3.9.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
+    <map name="articlesSerializedKeys">
+        <near-cache>
+            <in-memory-format>OBJECT</in-memory-format>
+            <serialize-keys>true</serialize-keys>
+            <cache-local-entries>true</cache-local-entries>
+            <invalidate-on-change>false</invalidate-on-change>
+            <eviction eviction-policy="NONE" max-size-policy="ENTRY_COUNT"/>
+        </near-cache>
+    </map>
+
     <map name="articlesObject">
         <near-cache>
             <in-memory-format>OBJECT</in-memory-format>

--- a/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithSerializedKeys.java
+++ b/jcache/src/main/java/com/hazelcast/examples/nearcache/ClientNearCacheWithSerializedKeys.java
@@ -1,0 +1,62 @@
+package com.hazelcast.examples.nearcache;
+
+import com.hazelcast.cache.ICache;
+import com.hazelcast.client.HazelcastClient;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.NearCacheConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.examples.Article;
+import com.hazelcast.examples.ArticleKey;
+
+public class ClientNearCacheWithSerializedKeys extends ClientNearCacheUsageSupport {
+
+    private static final int RECORD_COUNT = 100;
+
+    public void run() {
+        NearCacheConfig nearCacheConfig1 = createNearCacheConfig()
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setCacheLocalEntries(true)
+                .setInvalidateOnChange(false)
+                .setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        NearCacheConfig nearCacheConfig2 = createNearCacheConfig()
+                .setInMemoryFormat(InMemoryFormat.OBJECT)
+                .setSerializeKeys(true)
+                .setCacheLocalEntries(true)
+                .setInvalidateOnChange(false)
+                .setEvictionConfig(createEvictionConfigWithEntryCountPolicy(RECORD_COUNT * 2));
+
+        ICache<ArticleKey, Article> cache1 = createCacheWithNearCache(nearCacheConfig1);
+        ICache<ArticleKey, Article> cache2 = createCacheWithNearCache(nearCacheConfig2);
+
+        System.out.println("Near Cache of cache 1 uses serialized keys: " + nearCacheConfig1.isSerializeKeys());
+        System.out.println("Near Cache of cache 2 uses serialized keys: " + nearCacheConfig2.isSerializeKeys());
+
+        ArticleKey key1 = new ArticleKey(1);
+        ArticleKey key2 = new ArticleKey(2);
+        Article article = new Article("foo");
+
+        System.out.println("\nPopulate the data structure (both keys are serialized, since it's a remote operation)...");
+        cache1.put(key1, article);
+        cache2.put(key2, article);
+
+        System.out.println("\nThe first get() will populate the Near Cache (again a remote operation for both keys)...");
+        cache1.get(key1);
+        cache2.get(key2);
+
+        System.out.println("\nThe second get() will be served from the Near Cache (key 2 is serialized for the local lookup)...");
+        cache1.get(key1);
+        cache2.get(key2);
+
+        System.out.println("\nThe Near Cache statistics are the same (the key serialization is transparent to the user)...");
+        System.out.println("Near Cache from cache 1: " + cache1.getLocalCacheStatistics().getNearCacheStatistics());
+        System.out.println("Near Cache from cache 2: " + cache2.getLocalCacheStatistics().getNearCacheStatistics());
+        HazelcastClient.shutdownAll();
+        Hazelcast.shutdownAll();
+    }
+
+    public static void main(String[] args) {
+        ClientNearCacheWithSerializedKeys clientNearCacheUsage = new ClientNearCacheWithSerializedKeys();
+        clientNearCacheUsage.run();
+    }
+}


### PR DESCRIPTION
Sample output from the client map class:
```
Near Cache of map 1 uses serialized keys: false
Near Cache of map 2 uses serialized keys: true

Populate the data structure (both keys are serialized, since it's a remote operation)...
Called writeData() for key 1
Called writeData() for key 2

The first get() will populate the Near Cache (again a remote operation for both keys)...
Called writeData() for key 1
Called writeData() for key 2

The second get() will be served from the Near Cache (key 2 is serialized for the local
  lookup)...
Called writeData() for key 2

The Near Cache statistics are the same (the key serialization is transparent to the
  user)...
Near Cache from map 1: NearCacheStatsImpl{ownedEntryCount=1,
  ownedEntryMemoryCost=0, creationTime=1507544080426, hits=1, misses=1,
  ratio=100.0%, evictions=0, expirations=0, lastPersistenceTime=0,
  persistenceCount=0, lastPersistenceDuration=0,
  lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0,
  lastPersistenceFailure=''}
Near Cache from map 2: NearCacheStatsImpl{ownedEntryCount=1,
  ownedEntryMemoryCost=0, creationTime=1507544080427, hits=1, misses=1,
  ratio=100.0%, evictions=0, expirations=0, lastPersistenceTime=0,
  persistenceCount=0, lastPersistenceDuration=0,
  lastPersistenceWrittenBytes=0, lastPersistenceKeyCount=0,
  lastPersistenceFailure=''}
```