### PR TITLE
Use type parameters in distributed-executor samples

### DIFF
--- a/distributed-executor/durable-executor-service/src/main/java/retrieve/BasicTask.java
+++ b/distributed-executor/durable-executor-service/src/main/java/retrieve/BasicTask.java
@@ -19,7 +19,7 @@ package retrieve;
 import java.io.Serializable;
 import java.util.concurrent.Callable;
 
-public class BasicTask implements Callable, Serializable {
+public class BasicTask implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -28,7 +28,7 @@ public class BasicTask implements Callable, Serializable {
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/durable-executor-service/src/main/java/retrieve/RetrieveLostTask.java
+++ b/distributed-executor/durable-executor-service/src/main/java/retrieve/RetrieveLostTask.java
@@ -31,7 +31,7 @@ public class RetrieveLostTask {
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
         DurableExecutorService executorService = client.getDurableExecutorService("exec");
-        DurableExecutorServiceFuture future = executorService.submit(new BasicTask("DurableExecutor"));
+        DurableExecutorServiceFuture<String> future = executorService.submit(new BasicTask("DurableExecutor"));
         long taskId = future.getTaskId();
         client.shutdown();
 

--- a/distributed-executor/scheduled-executor-retrieve-all-tasks/src/main/java/EchoTask.java
+++ b/distributed-executor/scheduled-executor-retrieve-all-tasks/src/main/java/EchoTask.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 public class EchoTask
-        implements Callable, Serializable {
+        implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -27,7 +27,7 @@ public class EchoTask
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/scheduled-executor-retrieve-lost-future/src/main/java/EchoTask.java
+++ b/distributed-executor/scheduled-executor-retrieve-lost-future/src/main/java/EchoTask.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 public class EchoTask
-        implements Callable, Serializable {
+        implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -27,7 +27,7 @@ public class EchoTask
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/scheduled-executor-retrieve-lost-future/src/main/java/RetrieveLostFuture.java
+++ b/distributed-executor/scheduled-executor-retrieve-lost-future/src/main/java/RetrieveLostFuture.java
@@ -30,7 +30,7 @@ public class RetrieveLostFuture {
 
         HazelcastInstance client = HazelcastClient.newHazelcastClient();
         IScheduledExecutorService scheduler = client.getScheduledExecutorService("scheduler");
-        IScheduledFuture future = scheduler.schedule(new EchoTask("My Task"), 5, TimeUnit.SECONDS);
+        IScheduledFuture<String> future = scheduler.schedule(new EchoTask("My Task"), 5, TimeUnit.SECONDS);
 
         ScheduledTaskHandler handler = future.getHandler();
 
@@ -38,7 +38,7 @@ public class RetrieveLostFuture {
 
         HazelcastInstance newClient = HazelcastClient.newHazelcastClient();
         IScheduledExecutorService newScheduler = newClient.getScheduledExecutorService("scheduler");
-        IScheduledFuture newFuture = newScheduler.getScheduledFuture(handler);
+        IScheduledFuture<String> newFuture = newScheduler.getScheduledFuture(handler);
 
         Object result = newFuture.get();
         System.out.println("Result: " + result);

--- a/distributed-executor/scheduling-named-task/src/main/java/EchoTask.java
+++ b/distributed-executor/scheduling-named-task/src/main/java/EchoTask.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 public class EchoTask
-        implements Callable, Serializable {
+        implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -27,7 +27,7 @@ public class EchoTask
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/scheduling-named-task/src/main/java/MasterMember.java
+++ b/distributed-executor/scheduling-named-task/src/main/java/MasterMember.java
@@ -29,7 +29,7 @@ public class MasterMember {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance();
 
         IScheduledExecutorService scheduler = instance.getScheduledExecutorService("scheduler");
-        IScheduledFuture future = scheduler.schedule(named("MyTask",
+        IScheduledFuture<String> future = scheduler.schedule(named("MyTask",
                 new EchoTask("foobar")), 5, TimeUnit.SECONDS);
 
         Object result = future.get();

--- a/distributed-executor/scheduling-on-key-owner-durable/src/main/java/Cluster.java
+++ b/distributed-executor/scheduling-on-key-owner-durable/src/main/java/Cluster.java
@@ -33,7 +33,7 @@ public class Cluster {
 
         String key = generateKeyOwnedBy(instances[1]);
         IScheduledExecutorService scheduler = instances[0].getScheduledExecutorService("scheduler");
-        IScheduledFuture future = scheduler.scheduleOnKeyOwner(new EchoTask("My Task"), key, 5, TimeUnit.SECONDS);
+        IScheduledFuture<String> future = scheduler.scheduleOnKeyOwner(new EchoTask("My Task"), key, 5, TimeUnit.SECONDS);
 
         instances[1].getLifecycleService().terminate();
 

--- a/distributed-executor/scheduling-on-key-owner-durable/src/main/java/EchoTask.java
+++ b/distributed-executor/scheduling-on-key-owner-durable/src/main/java/EchoTask.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 public class EchoTask
-        implements Callable, Serializable {
+        implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -27,7 +27,7 @@ public class EchoTask
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/scheduling-on-specific-member/src/main/java/EchoTask.java
+++ b/distributed-executor/scheduling-on-specific-member/src/main/java/EchoTask.java
@@ -18,7 +18,7 @@ import java.io.Serializable;
 import java.util.concurrent.Callable;
 
 public class EchoTask
-        implements Callable, Serializable {
+        implements Callable<String>, Serializable {
 
     private final String msg;
 
@@ -27,7 +27,7 @@ public class EchoTask
     }
 
     @Override
-    public Object call() throws Exception {
+    public String call() throws Exception {
         return msg;
     }
 }

--- a/distributed-executor/scheduling-on-specific-member/src/main/java/MasterMember.java
+++ b/distributed-executor/scheduling-on-specific-member/src/main/java/MasterMember.java
@@ -27,7 +27,7 @@ public class MasterMember {
         HazelcastInstance instance = Hazelcast.newHazelcastInstance();
 
         IScheduledExecutorService scheduler = instance.getScheduledExecutorService("scheduler");
-        IScheduledFuture future = scheduler.scheduleOnMember(new EchoTask("My Task"),
+        IScheduledFuture<String> future = scheduler.scheduleOnMember(new EchoTask("My Task"),
                 instance.getCluster().getLocalMember(), 5, TimeUnit.SECONDS);
 
         Object result = future.get();

--- a/distributed-executor/scheduling-stateful-task/src/main/java/Cluster.java
+++ b/distributed-executor/scheduling-stateful-task/src/main/java/Cluster.java
@@ -35,7 +35,7 @@ public class Cluster {
         String key = generateKeyOwnedBy(taskOwner);
 
         IScheduledExecutorService scheduler = instances[0].getScheduledExecutorService("scheduler");
-        IScheduledFuture future = scheduler.scheduleOnKeyOwnerAtFixedRate(new EchoTask("My Task"),
+        IScheduledFuture<?> future = scheduler.scheduleOnKeyOwnerAtFixedRate(new EchoTask("My Task"),
                 key, 0, 5, TimeUnit.SECONDS);
 
         // Wait for a couple of run cycles


### PR DESCRIPTION
This commit avoids unchecked conversion compiler warnings in the `distributed-executor` samples.