### PR TITLE
Fixes hazelcast/hazelcast#11872

### DIFF
--- a/hazelcast-integration/spring-cache-manager/src/main/java/com/hazelcast/spring/cache/CachingConfiguration.java
+++ b/hazelcast-integration/spring-cache-manager/src/main/java/com/hazelcast/spring/cache/CachingConfiguration.java
@@ -3,12 +3,14 @@ package com.hazelcast.spring.cache;
 import com.hazelcast.client.HazelcastClient;
 import com.hazelcast.client.config.ClientConfig;
 import com.hazelcast.core.HazelcastInstance;
+
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CachingConfigurer;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.interceptor.KeyGenerator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 
 @Configuration
 @EnableCaching
@@ -28,5 +30,10 @@ class CachingConfiguration implements CachingConfigurer {
     @Bean
     public KeyGenerator keyGenerator() {
         return null;
+    }
+
+    @Bean
+    public PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
     }
 }


### PR DESCRIPTION
Sample (`hazelcast-integration/spring-cache-manager/AnnotationBasedCacheManager`) 
fails to start because of a missing `PropertySourcesPlaceholderConfigurer`. 
One is registered to the context to fix the sample. 

Reproducer described in the issue is fixed when a
`Cacheable` bean and a `PropertySourcesPlaceholderConfigurer` is registered
to the context. This seems like a Spring Framework bug as when upgraded to a newer 
version (`4.2.9.RELEASE` for example) the problem goes away (although I didn't care
to find the relevant issue on Spring issue tracker).

Fixes: https://github.com/hazelcast/hazelcast/issues/11872