### PR TITLE
Added example for new merge policies

### DIFF
--- a/helper/src/main/java/com/hazelcast/examples/helper/CommonUtils.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/CommonUtils.java
@@ -1,18 +1,42 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hazelcast.examples.helper;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.internal.partition.impl.PartitionServiceState;
+import com.hazelcast.nio.Address;
 import com.hazelcast.nio.ConnectionManager;
-import com.hazelcast.util.EmptyStatement;
 import com.hazelcast.util.ExceptionUtil;
 
 import java.io.Closeable;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
+import static com.hazelcast.examples.helper.HazelcastUtils.getAddress;
 import static com.hazelcast.examples.helper.HazelcastUtils.getNode;
+import static com.hazelcast.examples.helper.HazelcastUtils.getPartitionServiceState;
+import static com.hazelcast.util.EmptyStatement.ignore;
+import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -187,7 +211,52 @@ public final class CommonUtils {
         }
     }
 
-    public static void assertTrueEventually(Runnable task, long timeoutSeconds) {
+    public static void waitAllForSafeState(Collection<HazelcastInstance> instances) {
+        waitAllForSafeState(instances, 120);
+    }
+
+    public static void waitAllForSafeState(final Collection<HazelcastInstance> instances, int timeoutInSeconds) {
+        assertTrueEventually(new Runnable() {
+            public void run() {
+                assertAllInSafeState(instances);
+            }
+        }, timeoutInSeconds);
+    }
+
+    public static void waitAllForSafeState(final HazelcastInstance[] nodes, int timeoutInSeconds) {
+        assertTrueEventually(new Runnable() {
+            public void run() {
+                assertAllInSafeState(asList(nodes));
+            }
+        }, timeoutInSeconds);
+    }
+
+    public static void waitAllForSafeState(HazelcastInstance... nodes) {
+        if (nodes.length == 0) {
+            throw new IllegalArgumentException("waitAllForSafeState(HazelcastInstance... nodes) cannot be called with"
+                    + " an empty array. It's too easy to mistake it for the old argument-less waitAllForSafeState()."
+                    + " The old version was removed as it was implemented via Hazelcast.getAllHazelcastInstances()"
+                    + " which uses a static map internally and it's causing issues when tests are running in parallel.");
+        }
+        waitAllForSafeState(asList(nodes));
+    }
+
+    public static void assertAllInSafeState(Collection<HazelcastInstance> nodes) {
+        Map<Address, PartitionServiceState> nonSafeStates = new HashMap<Address, PartitionServiceState>();
+        for (HazelcastInstance node : nodes) {
+            if (node == null) {
+                continue;
+            }
+            final PartitionServiceState state = getPartitionServiceState(node);
+            if (state != PartitionServiceState.SAFE) {
+                nonSafeStates.put(getAddress(node), state);
+            }
+        }
+
+        assertTrue("Instances not in safe state! " + nonSafeStates, nonSafeStates.isEmpty());
+    }
+
+   public static void assertTrueEventually(Runnable task, long timeoutSeconds) {
         try {
             AssertionError error = null;
             // we are going to check 5 times a second
@@ -219,7 +288,7 @@ public final class CommonUtils {
         try {
             closeable.close();
         } catch (IOException ignored) {
-            EmptyStatement.ignore(ignored);
+            ignore(ignored);
         }
     }
 }

--- a/helper/src/main/java/com/hazelcast/examples/helper/nio/DroppingConnection.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/nio/DroppingConnection.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.nio;
+
+import com.hazelcast.internal.networking.OutboundFrame;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.ConnectionType;
+import com.hazelcast.util.Clock;
+import com.hazelcast.util.ExceptionUtil;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+class DroppingConnection implements Connection {
+
+    private final Address endpoint;
+    private final long timestamp = Clock.currentTimeMillis();
+    private final ConnectionManager connectionManager;
+    private AtomicBoolean isAlive = new AtomicBoolean(true);
+
+    DroppingConnection(Address endpoint, ConnectionManager connectionManager) {
+        this.endpoint = endpoint;
+        this.connectionManager = connectionManager;
+    }
+
+    @Override
+    public Throwable getCloseCause() {
+        return null;
+    }
+
+    @Override
+    public String getCloseReason() {
+        return null;
+    }
+
+    @Override
+    public boolean write(OutboundFrame frame) {
+        return true;
+    }
+
+    @Override
+    public boolean isAlive() {
+        return isAlive.get();
+    }
+
+    @Override
+    public long lastReadTimeMillis() {
+        return timestamp;
+    }
+
+    @Override
+    public long lastWriteTimeMillis() {
+        return timestamp;
+    }
+
+    @Override
+    public void close(String msg, Throwable cause) {
+        if (!isAlive.compareAndSet(true, false)) {
+            return;
+        }
+        connectionManager.onConnectionClose(this);
+    }
+
+    @Override
+    public void setType(ConnectionType type) {
+        //NO OP
+    }
+
+    @Override
+    public ConnectionType getType() {
+        return ConnectionType.MEMBER;
+    }
+
+    @Override
+    public boolean isClient() {
+        return false;
+    }
+
+    @Override
+    public InetAddress getInetAddress() {
+        try {
+            return endpoint.getInetAddress();
+        } catch (UnknownHostException e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    @Override
+    public InetSocketAddress getRemoteSocketAddress() {
+        try {
+            return endpoint.getInetSocketAddress();
+        } catch (UnknownHostException e) {
+            throw ExceptionUtil.rethrow(e);
+        }
+    }
+
+    @Override
+    public Address getEndPoint() {
+        return endpoint;
+    }
+
+    @Override
+    public int getPort() {
+        return endpoint.getPort();
+    }
+}

--- a/helper/src/main/java/com/hazelcast/examples/helper/nio/FirewallingConnectionManager.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/nio/FirewallingConnectionManager.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.nio;
+
+import com.hazelcast.internal.util.concurrent.ThreadFactoryImpl;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Connection;
+import com.hazelcast.nio.ConnectionListener;
+import com.hazelcast.nio.ConnectionManager;
+import com.hazelcast.nio.Packet;
+import com.hazelcast.spi.impl.PacketHandler;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+
+import static java.util.concurrent.Executors.newSingleThreadScheduledExecutor;
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+
+/**
+ * A {@link ConnectionManager} wrapper which adds firewalling capabilities.
+ * All methods delegate to the original ConnectionManager.
+ */
+public class FirewallingConnectionManager implements ConnectionManager, PacketHandler {
+
+    private final ConnectionManager delegate;
+    private final Set<Address> blockedAddresses = Collections.newSetFromMap(new ConcurrentHashMap<Address, Boolean>());
+    private final ScheduledExecutorService scheduledExecutor
+            = newSingleThreadScheduledExecutor(new ThreadFactoryImpl("FirewallingConnectionManager"));
+    private final PacketHandler packetHandler;
+
+    private volatile PacketFilter packetFilter;
+    private volatile PacketDelayProps delayProps = new PacketDelayProps(500, 5000);
+
+    public FirewallingConnectionManager(ConnectionManager delegate, Set<Address> initiallyBlockedAddresses) {
+        this.delegate = delegate;
+        this.blockedAddresses.addAll(initiallyBlockedAddresses);
+        this.packetHandler = delegate instanceof PacketHandler ? (PacketHandler) delegate : null;
+    }
+
+    @Override
+    public synchronized Connection getOrConnect(Address address) {
+        Connection connection = getConnection(address);
+        if (connection != null && connection.isAlive()) {
+            return connection;
+        }
+        if (blockedAddresses.contains(address)) {
+            connection = new DroppingConnection(address, this);
+            registerConnection(address, connection);
+            return connection;
+        } else {
+            return delegate.getOrConnect(address);
+        }
+    }
+
+    @Override
+    public synchronized Connection getOrConnect(Address address, boolean silent) {
+        return getOrConnect(address);
+    }
+
+    public synchronized void blockNewConnection(Address address) {
+        blockedAddresses.add(address);
+    }
+
+    public synchronized void closeActiveConnection(Address address) {
+        Connection connection = getConnection(address);
+        if (connection != null) {
+            connection.close("Blocked by connection manager", null);
+        }
+    }
+
+    public synchronized void unblock(Address address) {
+        blockedAddresses.remove(address);
+        Connection connection = getConnection(address);
+        if (connection instanceof DroppingConnection) {
+            connection.close(null, null);
+        }
+    }
+
+    public void setPacketFilter(PacketFilter packetFilter) {
+        assert packetFilter != null;
+        this.packetFilter = packetFilter;
+    }
+
+    public void removePacketFilter() {
+        packetFilter = null;
+    }
+
+    public void setDelayMillis(long minDelayMs, long maxDelayMs) {
+        assert minDelayMs > 0 : "Min delay must be positive: " + minDelayMs;
+        assert maxDelayMs > 0 : "Max delay must be positive: " + minDelayMs;
+        assert maxDelayMs >= minDelayMs : "Max delay must not be smaller than min delay. Max: " + maxDelayMs
+                + ", min: " + minDelayMs;
+        this.delayProps = new PacketDelayProps(minDelayMs, maxDelayMs);
+    }
+
+    private PacketFilter.Action applyFilter(Packet packet, Address target) {
+        if (blockedAddresses.contains(target)) {
+            return PacketFilter.Action.REJECT;
+        }
+
+        PacketFilter filter = packetFilter;
+        return filter == null ? PacketFilter.Action.ALLOW : filter.filter(packet, target);
+    }
+
+    private long getDelayMs() {
+        PacketDelayProps delay = delayProps;
+        return getRandomBetween(delay.maxDelayMs, delay.minDelayMs);
+    }
+
+    private static long getRandomBetween(long max, long min) {
+        return (long) ((max - min) * Math.random() + min);
+    }
+
+    @Override
+    public boolean transmit(Packet packet, Connection connection) {
+        if (connection != null) {
+            PacketFilter.Action action = applyFilter(packet, connection.getEndPoint());
+            switch (action) {
+                case DROP:
+                    return true;
+                case REJECT:
+                    return false;
+                case DELAY:
+                    scheduledExecutor.schedule(new DelayedPacketTask(packet, connection), getDelayMs(), MILLISECONDS);
+                    return true;
+                default:
+                    return delegate.transmit(packet, connection);
+            }
+        }
+        return delegate.transmit(packet, (Connection) null);
+    }
+
+    @Override
+    public boolean transmit(Packet packet, Address target) {
+        PacketFilter.Action action = applyFilter(packet, target);
+        switch (action) {
+            case DROP:
+                return true;
+            case REJECT:
+                return false;
+            case DELAY:
+                scheduledExecutor.schedule(new DelayedPacketTask(packet, target), getDelayMs(), MILLISECONDS);
+                return true;
+            default:
+                return delegate.transmit(packet, target);
+        }
+    }
+
+    @Override
+    public int getCurrentClientConnections() {
+        return delegate.getCurrentClientConnections();
+    }
+
+    @Override
+    public void addConnectionListener(ConnectionListener listener) {
+        delegate.addConnectionListener(listener);
+    }
+
+    @Override
+    public int getAllTextConnections() {
+        return delegate.getAllTextConnections();
+    }
+
+    @Override
+    public int getConnectionCount() {
+        return delegate.getConnectionCount();
+    }
+
+    @Override
+    public int getActiveConnectionCount() {
+        return delegate.getActiveConnectionCount();
+    }
+
+    @Override
+    public Connection getConnection(Address address) {
+        return delegate.getConnection(address);
+    }
+
+    @Override
+    public boolean registerConnection(Address address, Connection connection) {
+        return delegate.registerConnection(address, connection);
+    }
+
+    @Override
+    public void onConnectionClose(Connection connection) {
+        delegate.onConnectionClose(connection);
+    }
+
+    @Override
+    public void start() {
+        delegate.start();
+    }
+
+    @Override
+    public void stop() {
+        delegate.stop();
+    }
+
+    @Override
+    public void shutdown() {
+        delegate.shutdown();
+        scheduledExecutor.shutdown();
+    }
+
+    @Override
+    public void handle(Packet packet) throws Exception {
+        if (packetHandler == null) {
+            throw new UnsupportedOperationException(delegate + " is not instance of PacketHandler!");
+        }
+        packetHandler.handle(packet);
+    }
+
+    private class DelayedPacketTask implements Runnable {
+
+        final Packet packet;
+        final Connection connection;
+        final Address target;
+
+        DelayedPacketTask(Packet packet, Connection connection) {
+            assert connection != null;
+            this.packet = packet;
+            this.connection = connection;
+            this.target = null;
+        }
+
+        DelayedPacketTask(Packet packet, Address target) {
+            assert target != null;
+            this.packet = packet;
+            this.connection = null;
+            this.target = target;
+        }
+
+        @Override
+        public void run() {
+            if (connection != null) {
+                delegate.transmit(packet, connection);
+            } else {
+                delegate.transmit(packet, target);
+            }
+        }
+    }
+
+    private static final class PacketDelayProps {
+
+        final long minDelayMs;
+        final long maxDelayMs;
+
+        private PacketDelayProps(long minDelayMs, long maxDelayMs) {
+            this.minDelayMs = minDelayMs;
+            this.maxDelayMs = maxDelayMs;
+        }
+    }
+}

--- a/helper/src/main/java/com/hazelcast/examples/helper/nio/FirewallingNodeContext.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/nio/FirewallingNodeContext.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.nio;
+
+import com.hazelcast.instance.DefaultNodeContext;
+import com.hazelcast.instance.Node;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.ConnectionManager;
+
+import java.nio.channels.ServerSocketChannel;
+import java.util.Collections;
+
+/**
+ * Creates a {@link DefaultNodeContext} with wrapping its ConnectionManager
+ * with a {@link FirewallingConnectionManager}.
+ */
+public class FirewallingNodeContext extends DefaultNodeContext {
+
+    @Override
+    public ConnectionManager createConnectionManager(Node node, ServerSocketChannel serverSocketChannel) {
+        ConnectionManager connectionManager = super.createConnectionManager(node, serverSocketChannel);
+        return new FirewallingConnectionManager(connectionManager, Collections.<Address>emptySet());
+    }
+}

--- a/helper/src/main/java/com/hazelcast/examples/helper/nio/PacketFilter.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/nio/PacketFilter.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.nio;
+
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Packet;
+
+/**
+ * A filter used by network system to allow, reject, drop or delay {@code Packet}s
+ */
+public interface PacketFilter {
+
+    enum Action {
+        /**
+         * Allows the packet to pass through intact
+         */
+        ALLOW,
+
+        /**
+         * Rejects the packet. Sender will be aware of rejection.
+         */
+        REJECT,
+
+        /**
+         * Silently drops the packet as if sent to the destination.
+         */
+        DROP,
+
+        /**
+         * Delays sending packet to the destination.
+         */
+        DELAY
+    }
+
+    /**
+     * Filters a packet inspecting its content and/or endpoint and decides
+     * whether this packet should be filtered.
+     *
+     * @param packet   packet
+     * @param endpoint target endpoint which packet is sent to
+     * @return returns An {@link Action} to denote whether packet should pass through intact,
+     * or should be rejected/dropped/delayed
+     */
+    Action filter(Packet packet, Address endpoint);
+
+}

--- a/helper/src/main/java/com/hazelcast/examples/helper/splitbrain/MergeBarrier.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/splitbrain/MergeBarrier.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.splitbrain;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.core.LifecycleService;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGE_FAILED;
+import static com.hazelcast.core.LifecycleEvent.LifecycleState.MERGING;
+import static com.hazelcast.examples.helper.CommonUtils.sleepAtLeastMillis;
+
+/**
+ * Protects against in-progress merging.
+ */
+class MergeBarrier {
+
+    private final AtomicInteger mergedInProgress = new AtomicInteger();
+    private final Map<HazelcastInstance, String> registrations = new HashMap<HazelcastInstance, String>();
+
+    MergeBarrier(HazelcastInstance[] instances) {
+        MergeCountingListener mergeCountingListener = new MergeCountingListener();
+
+        for (HazelcastInstance instance : instances) {
+            LifecycleService lifecycleService = instance.getLifecycleService();
+            if (lifecycleService.isRunning()) {
+                String registration = lifecycleService.addLifecycleListener(mergeCountingListener);
+                registrations.put(instance, registration);
+            }
+        }
+    }
+
+    /**
+     * Await until there is no merging in progress.
+     */
+    public void awaitNoMergeInProgressAndClose() {
+        while (mergedInProgress.get() != 0) {
+            sleepAtLeastMillis(10);
+        }
+        close();
+    }
+
+    private void close() {
+        for (Map.Entry<HazelcastInstance, String> entry : registrations.entrySet()) {
+            HazelcastInstance instance = entry.getKey();
+            String registration = entry.getValue();
+
+            instance.getLifecycleService().removeLifecycleListener(registration);
+        }
+    }
+
+    private class MergeCountingListener implements LifecycleListener {
+        @Override
+        public void stateChanged(LifecycleEvent event) {
+            LifecycleEvent.LifecycleState state = event.getState();
+            if (state.equals(MERGING)) {
+                mergedInProgress.incrementAndGet();
+            } else if (state.equals(MERGED)) {
+                mergedInProgress.decrementAndGet();
+            } else if (state.equals(MERGE_FAILED)) {
+                mergedInProgress.decrementAndGet();
+            }
+        }
+    }
+}

--- a/helper/src/main/java/com/hazelcast/examples/helper/splitbrain/SplitBrainTestSupport.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/splitbrain/SplitBrainTestSupport.java
@@ -1,0 +1,402 @@
+/*
+ * Copyright (c) 2008-2016, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.examples.helper.splitbrain;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceNotActiveException;
+import com.hazelcast.core.LifecycleEvent;
+import com.hazelcast.core.LifecycleListener;
+import com.hazelcast.examples.helper.nio.FirewallingConnectionManager;
+import com.hazelcast.examples.helper.nio.FirewallingNodeContext;
+import com.hazelcast.instance.HazelcastInstanceFactory;
+import com.hazelcast.instance.HazelcastInstanceImpl;
+import com.hazelcast.instance.HazelcastInstanceProxy;
+import com.hazelcast.instance.Node;
+import com.hazelcast.instance.NodeState;
+import com.hazelcast.spi.properties.GroupProperty;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.hazelcast.examples.helper.CommonUtils.assertClusterSizeEventually;
+import static com.hazelcast.examples.helper.CommonUtils.assertOpenEventually;
+import static com.hazelcast.examples.helper.CommonUtils.waitAllForSafeState;
+import static com.hazelcast.examples.helper.HazelcastUtils.closeConnectionBetween;
+import static com.hazelcast.examples.helper.HazelcastUtils.getNode;
+
+/**
+ * A support class for high-level split-brain tests.
+ * <p>
+ * Forms a cluster, creates a split-brain situation and then heals the cluster again.
+ * <p>
+ * Implementing tests are supposed to subclass this class and use its hooks to be notified about state transitions.
+ * See {@link #onBeforeSplitBrainCreated(HazelcastInstance[])},
+ * {@link #onAfterSplitBrainCreated(HazelcastInstance[], HazelcastInstance[])}
+ * and {@link #onAfterSplitBrainHealed(HazelcastInstance[])}
+ * <p>
+ * The current implementation always isolates the first member of the cluster, but it should be simple to customize this
+ * class to support mode advanced split-brain scenarios.
+ */
+@SuppressWarnings("WeakerAccess")
+public abstract class SplitBrainTestSupport {
+
+    // per default the second half should merge into the first half
+    private static final int[] DEFAULT_BRAINS = new int[]{2, 1};
+    private static final int DEFAULT_ITERATION_COUNT = 1;
+    private static final AtomicInteger FACTORY_ID_GEN = new AtomicInteger();
+
+    private static final SplitBrainAction BLOCK_COMMUNICATION = new SplitBrainAction() {
+        @Override
+        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
+            blockCommunicationBetween(h1, h2);
+        }
+    };
+
+    private static final SplitBrainAction UNBLOCK_COMMUNICATION = new SplitBrainAction() {
+        @Override
+        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
+            unblockCommunicationBetween(h1, h2);
+        }
+    };
+
+    private static final SplitBrainAction CLOSE_CONNECTION = new SplitBrainAction() {
+        @Override
+        public void apply(HazelcastInstance h1, HazelcastInstance h2) {
+            closeConnectionBetween(h1, h2);
+        }
+    };
+
+    private int[] brains;
+    private HazelcastInstance[] instances;
+
+    public SplitBrainTestSupport() {
+        brains = brains();
+        validateBrainsConfig(brains);
+    }
+
+    public void run() throws Exception {
+        try {
+            onBeforeSetup();
+
+            Config config = config();
+            int clusterSize = getClusterSize();
+            instances = startInitialCluster(config, clusterSize);
+
+            for (int i = 0; i < iterations(); i++) {
+                doIteration();
+            }
+        } finally {
+            for (HazelcastInstance hazelcastInstance : Hazelcast.getAllHazelcastInstances()) {
+                hazelcastInstance.getLifecycleService().terminate();
+            }
+        }
+    }
+
+    /**
+     * Override this method to execute initialization that may be required before instantiating the cluster. This is the
+     * first method executed by {@code @Before SplitBrainTestSupport.setupInternals}.
+     */
+    protected void onBeforeSetup() {
+    }
+
+    /**
+     * Override this method to create a custom brain sizes
+     *
+     * @return the default number of brains
+     */
+    protected int[] brains() {
+        return DEFAULT_BRAINS;
+    }
+
+    /**
+     * Override this method to create a custom Hazelcast configuration.
+     *
+     * @return the default Hazelcast configuration
+     */
+    protected Config config() {
+        return new Config()
+                .setProperty(GroupProperty.PARTITION_COUNT.getName(), "11")
+                .setProperty(GroupProperty.PARTITION_OPERATION_THREAD_COUNT.getName(), "2")
+                .setProperty(GroupProperty.GENERIC_OPERATION_THREAD_COUNT.getName(), "2")
+                .setProperty(GroupProperty.EVENT_THREAD_COUNT.getName(), "1")
+                .setProperty(GroupProperty.MERGE_FIRST_RUN_DELAY_SECONDS.getName(), "5")
+                .setProperty(GroupProperty.MERGE_NEXT_RUN_DELAY_SECONDS.getName(), "5");
+    }
+
+    /**
+     * Override this method to create the split-brain situation multiple-times.
+     * <p>
+     * The test will use the same members for all iterations.
+     *
+     * @return the default number of iterations
+     */
+    protected int iterations() {
+        return DEFAULT_ITERATION_COUNT;
+    }
+
+    /**
+     * Called when a cluster is fully formed. You can use this method for test initialization, data load, etc.
+     *
+     * @param instances all Hazelcast instances in your cluster
+     */
+    @SuppressWarnings({"RedundantThrows", "unused"})
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) throws Exception {
+    }
+
+    /**
+     * Called just after a split brain situation was created
+     */
+    @SuppressWarnings({"RedundantThrows", "unused"})
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) throws Exception {
+    }
+
+    /**
+     * Called just after the original cluster was healed again. This is likely the place for various asserts.
+     *
+     * @param instances all Hazelcast instances in your cluster
+     */
+    @SuppressWarnings({"RedundantThrows", "unused"})
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) throws Exception {
+    }
+
+    /**
+     * Indicates whether test should fail when cluster does not include all original members after communications are unblocked.
+     * <p>
+     * Override this method when it is expected that after communications are unblocked some members will not rejoin the cluster.
+     * When overriding this method, it may be desirable to add some wait time to allow the split brain handler to execute.
+     *
+     * @return {@code true} if the test should fail when not all original members rejoin after split brain is
+     * healed, otherwise {@code false}.
+     */
+    protected boolean shouldAssertAllNodesRejoined() {
+        return true;
+    }
+
+    private void doIteration() throws Exception {
+        onBeforeSplitBrainCreated(instances);
+
+        createSplitBrain();
+        Brains brains = getBrains();
+        onAfterSplitBrainCreated(brains.getFirstHalf(), brains.getSecondHalf());
+
+        healSplitBrain();
+        onAfterSplitBrainHealed(instances);
+    }
+
+    protected HazelcastInstance[] startInitialCluster(Config config, int clusterSize) {
+        HazelcastInstance[] hazelcastInstances = new HazelcastInstance[clusterSize];
+        for (int i = 0; i < clusterSize; i++) {
+            hazelcastInstances[i] = HazelcastInstanceFactory.newHazelcastInstance(config, createInstanceName(config),
+                    new FirewallingNodeContext());
+        }
+        return hazelcastInstances;
+    }
+
+    public static String createInstanceName(Config config) {
+        return "_hzInstance_" + FACTORY_ID_GEN.incrementAndGet() + "_" + config.getGroupConfig().getName();
+    }
+
+    private void validateBrainsConfig(int[] clusterTopology) {
+        if (clusterTopology.length != 2) {
+            throw new AssertionError("Only simple topologies with 2 brains are supported. Current setup: "
+                    + Arrays.toString(clusterTopology));
+        }
+    }
+
+    private int getClusterSize() {
+        int clusterSize = 0;
+        for (int brainSize : brains) {
+            clusterSize += brainSize;
+        }
+        return clusterSize;
+    }
+
+    private void createSplitBrain() {
+        blockCommunications();
+        closeExistingConnections();
+        assertSplitBrainCreated();
+    }
+
+    private void assertSplitBrainCreated() {
+        int firstHalfSize = brains[0];
+        for (int isolatedIndex = 0; isolatedIndex < firstHalfSize; isolatedIndex++) {
+            HazelcastInstance isolatedInstance = instances[isolatedIndex];
+            assertClusterSizeEventually(firstHalfSize, isolatedInstance);
+        }
+        for (int i = firstHalfSize; i < instances.length; i++) {
+            HazelcastInstance currentInstance = instances[i];
+            assertClusterSizeEventually(instances.length - firstHalfSize, currentInstance);
+        }
+    }
+
+    private void closeExistingConnections() {
+        applyOnBrains(CLOSE_CONNECTION);
+    }
+
+    private void blockCommunications() {
+        applyOnBrains(BLOCK_COMMUNICATION);
+    }
+
+    private void healSplitBrain() {
+        MergeBarrier mergeBarrier = new MergeBarrier(instances);
+        try {
+            unblockCommunication();
+            if (shouldAssertAllNodesRejoined()) {
+                for (HazelcastInstance hz : instances) {
+                    assertClusterSizeEventually(instances.length, hz);
+                }
+            }
+            waitAllForSafeState(instances);
+        } finally {
+            mergeBarrier.awaitNoMergeInProgressAndClose();
+        }
+    }
+
+    private void unblockCommunication() {
+        applyOnBrains(UNBLOCK_COMMUNICATION);
+    }
+
+    private static FirewallingConnectionManager getFireWalledConnectionManager(HazelcastInstance hz) {
+        return (FirewallingConnectionManager) getNode(hz).getConnectionManager();
+    }
+
+    protected Brains getBrains() {
+        int firstHalfSize = brains[0];
+        int secondHalfSize = brains[1];
+        HazelcastInstance[] firstHalf = new HazelcastInstance[firstHalfSize];
+        HazelcastInstance[] secondHalf = new HazelcastInstance[secondHalfSize];
+        for (int i = 0; i < instances.length; i++) {
+            if (i < firstHalfSize) {
+                firstHalf[i] = instances[i];
+            } else {
+                secondHalf[i - firstHalfSize] = instances[i];
+            }
+        }
+        return new Brains(firstHalf, secondHalf);
+    }
+
+    private void applyOnBrains(SplitBrainAction action) {
+        int firstHalfSize = brains[0];
+        for (int isolatedIndex = 0; isolatedIndex < firstHalfSize; isolatedIndex++) {
+            HazelcastInstance isolatedInstance = instances[isolatedIndex];
+            // do not take into account instances which have been shutdown
+            if (!isInstanceActive(isolatedInstance)) {
+                continue;
+            }
+            for (int i = firstHalfSize; i < instances.length; i++) {
+                HazelcastInstance currentInstance = instances[i];
+                if (!isInstanceActive(currentInstance)) {
+                    continue;
+                }
+                action.apply(isolatedInstance, currentInstance);
+            }
+        }
+    }
+
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
+    private static boolean isInstanceActive(HazelcastInstance instance) {
+        if (instance instanceof HazelcastInstanceProxy) {
+            try {
+                return ((HazelcastInstanceProxy) instance).getOriginal() != null;
+            } catch (HazelcastInstanceNotActiveException exception) {
+                return false;
+            }
+        } else if (instance instanceof HazelcastInstanceImpl) {
+            return getNode(instance).getState() == NodeState.ACTIVE;
+        } else {
+            throw new AssertionError("Unsupported HazelcastInstance type");
+        }
+    }
+
+    public static void blockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
+        FirewallingConnectionManager cm1 = getFireWalledConnectionManager(h1);
+        FirewallingConnectionManager cm2 = getFireWalledConnectionManager(h2);
+        Node node1 = getNode(h1);
+        Node node2 = getNode(h2);
+        cm1.blockNewConnection(node2.getThisAddress());
+        cm2.blockNewConnection(node1.getThisAddress());
+        cm1.closeActiveConnection(node2.getThisAddress());
+        cm2.closeActiveConnection(node1.getThisAddress());
+    }
+
+    public static void unblockCommunicationBetween(HazelcastInstance h1, HazelcastInstance h2) {
+        FirewallingConnectionManager cm1 = getFireWalledConnectionManager(h1);
+        FirewallingConnectionManager cm2 = getFireWalledConnectionManager(h2);
+        Node node1 = getNode(h1);
+        Node node2 = getNode(h2);
+        cm1.unblock(node2.getThisAddress());
+        cm2.unblock(node1.getThisAddress());
+    }
+
+    public static String toString(Collection collection) {
+        StringBuilder sb = new StringBuilder("[");
+        String delimiter = "";
+        for (Object item : collection) {
+            sb.append(delimiter).append(item);
+            delimiter = ", ";
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private interface SplitBrainAction {
+        void apply(HazelcastInstance h1, HazelcastInstance h2);
+    }
+
+    protected static final class Brains {
+
+        private final HazelcastInstance[] firstHalf;
+        private final HazelcastInstance[] secondHalf;
+
+        private Brains(HazelcastInstance[] firstHalf, HazelcastInstance[] secondHalf) {
+            this.firstHalf = firstHalf;
+            this.secondHalf = secondHalf;
+        }
+
+        public HazelcastInstance[] getFirstHalf() {
+            return firstHalf;
+        }
+
+        public HazelcastInstance[] getSecondHalf() {
+            return secondHalf;
+        }
+    }
+
+    protected static final class MergeLifecycleListener implements LifecycleListener {
+
+        private final CountDownLatch latch;
+
+        public MergeLifecycleListener(int mergingClusterSize) {
+            latch = new CountDownLatch(mergingClusterSize);
+        }
+
+        @Override
+        public void stateChanged(LifecycleEvent event) {
+            if (event.getState() == LifecycleEvent.LifecycleState.MERGED) {
+                latch.countDown();
+            }
+        }
+
+        public void await() {
+            assertOpenEventually(latch);
+        }
+    }
+}

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -26,6 +26,7 @@
         <module>partition-migration</module>
         <module>priority-queue</module>
         <module>proxy</module>
+        <module>split-brain</module>
     </modules>
 
     <properties>

--- a/spi/split-brain/pom.xml
+++ b/spi/split-brain/pom.xml
@@ -1,0 +1,32 @@
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>jar</packaging>
+
+    <artifactId>split-brain</artifactId>
+    <name>SPI: Split-brain healing</name>
+    <description>
+        The code example for the split-brain healing and custom merge policies
+    </description>
+
+    <parent>
+        <groupId>com.hazelcast.samples.spi</groupId>
+        <artifactId>spi</artifactId>
+        <version>0.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <properties>
+        <!-- needed for checkstyle/findbugs -->
+        <main.basedir>${project.parent.parent.basedir}</main.basedir>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.hazelcast.samples</groupId>
+            <artifactId>helper</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/spi/split-brain/src/main/java/AbstractMapMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/AbstractMapMergePolicyExample.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InMemoryFormat;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IMap;
+import com.hazelcast.examples.helper.splitbrain.SplitBrainTestSupport;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+abstract class AbstractMapMergePolicyExample extends SplitBrainTestSupport {
+
+    private static final String MAP_NAME = "myMap";
+
+    IMap<Object, Object> map1;
+    IMap<Object, Object> map2;
+
+    private final Class<? extends SplitBrainMergePolicy> mergePolicyClass;
+
+    private MergeLifecycleListener mergeLifecycleListener;
+
+    AbstractMapMergePolicyExample(Class<? extends SplitBrainMergePolicy> mergePolicyClass) {
+        this.mergePolicyClass = mergePolicyClass;
+    }
+
+    @Override
+    protected Config config() {
+        // for a custom merge policy we have to provide the FQCN, not just the simple classname
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(mergePolicyClass.getName());
+
+        MapConfig mapConfig = new MapConfig()
+                .setName(MAP_NAME)
+                .setInMemoryFormat(InMemoryFormat.BINARY)
+                .setBackupCount(1)
+                .setAsyncBackupCount(0)
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        return super.config()
+                //.setProperty("hazelcast.logging.type", "none")
+                .addMapConfig(mapConfig);
+    }
+
+    @Override
+    protected void onBeforeSplitBrainCreated(HazelcastInstance[] instances) {
+        System.out.println("========================== Cluster is created!");
+    }
+
+    @Override
+    protected void onAfterSplitBrainCreated(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        mergeLifecycleListener = new MergeLifecycleListener(secondBrain.length);
+        for (HazelcastInstance instance : secondBrain) {
+            instance.getLifecycleService().addLifecycleListener(mergeLifecycleListener);
+        }
+
+        map1 = firstBrain[0].getMap(MAP_NAME);
+        map2 = secondBrain[0].getMap(MAP_NAME);
+
+        System.out.println("========================== Cluster is split!");
+
+        duringSplitBrain(firstBrain, secondBrain);
+    }
+
+    @Override
+    protected void onAfterSplitBrainHealed(HazelcastInstance[] instances) {
+        // wait until merge completes
+        mergeLifecycleListener.await();
+
+        System.out.println("========================== Cluster is merged!");
+
+        afterSplitBrain(instances);
+    }
+
+    abstract void duringSplitBrain(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain);
+
+    abstract void afterSplitBrain(HazelcastInstance[] instances);
+}

--- a/spi/split-brain/src/main/java/ComposedHitsAndCreationTimeMapMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/ComposedHitsAndCreationTimeMapMergePolicyExample.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.ComposedHitsAndCreationTimeMergePolicy;
+
+import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
+import static com.hazelcast.examples.helper.CommonUtils.sleepMillis;
+
+/**
+ * Shows the split-brain healing via the {@link ComposedHitsAndCreationTimeMergePolicy}.
+ */
+public final class ComposedHitsAndCreationTimeMapMergePolicyExample extends AbstractMapMergePolicyExample {
+
+    private ComposedHitsAndCreationTimeMapMergePolicyExample() {
+        super(ComposedHitsAndCreationTimeMergePolicy.class);
+    }
+
+    @Override
+    void duringSplitBrain(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        // putting the older values
+        map1.put("key1", "large-value1");
+
+        map2.put("key2", "small-value2");
+        map2.put("key3", "small-value3");
+
+        sleepMillis(500);
+
+        // putting the newer values
+        map1.put("key2", "large-value2");
+        map1.put("key3", "large-value3");
+
+        map2.put("key1", "small-value1");
+
+        // increasing the hits
+        map1.get("key2");
+        map1.get("key2");
+        map1.get("key2");
+
+        map2.get("key3");
+        map2.get("key3");
+        map2.get("key3");
+
+        System.out.println("========================== Map size (larger cluster): " + map1.size());
+        System.out.println("========================== Value for \"key1\" (larger cluster): " + map1.get("key1"));
+        System.out.println("========================== Value for \"key2\" (larger cluster): " + map1.get("key2"));
+        System.out.println("========================== Value for \"key3\" (larger cluster): " + map1.get("key3"));
+
+        System.out.println("========================== Map size (smaller cluster): " + map2.size());
+        System.out.println("========================== Value for \"key1\" (smaller cluster): " + map2.get("key1"));
+        System.out.println("========================== Value for \"key2\" (smaller cluster): " + map2.get("key2"));
+        System.out.println("========================== Value for \"key3\" (smaller cluster): " + map2.get("key3"));
+    }
+
+    @Override
+    void afterSplitBrain(HazelcastInstance[] instances) {
+        System.out.println("========================== Map size (merged cluster): " + map1.size());
+        System.out.println("========================== Value for \"key1\" (merged cluster): " + map1.get("key1"));
+        System.out.println("========================== Value for \"key2\" (merged cluster): " + map1.get("key2"));
+        System.out.println("========================== Value for \"key3\" (merged cluster): " + map1.get("key3"));
+
+        assertEquals(3, map1.size());
+        assertEquals(3, map2.size());
+
+        assertEquals("large-value1", map1.get("key1"));
+        assertEquals("large-value1", map2.get("key1"));
+
+        assertEquals("large-value2", map1.get("key2"));
+        assertEquals("large-value2", map2.get("key2"));
+
+        assertEquals("small-value3", map1.get("key3"));
+        assertEquals("small-value3", map2.get("key3"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        ComposedHitsAndCreationTimeMapMergePolicyExample mergePolicyExample
+                = new ComposedHitsAndCreationTimeMapMergePolicyExample();
+        mergePolicyExample.run();
+    }
+}

--- a/spi/split-brain/src/main/java/MapEntryCostsMapMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/MapEntryCostsMapMergePolicyExample.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.MapEntryCostsMergePolicy;
+
+import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
+
+/**
+ * Shows the split-brain healing via the {@link MapEntryCostsMergePolicy}.
+ */
+public final class MapEntryCostsMapMergePolicyExample extends AbstractMapMergePolicyExample {
+
+    private MapEntryCostsMapMergePolicyExample() {
+        super(MapEntryCostsMergePolicy.class);
+    }
+
+    @Override
+    void duringSplitBrain(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        map1.put("key", "value");
+        map2.put("key", "bigger-value");
+
+        System.out.println("========================== Map size (larger cluster): " + map1.size());
+        System.out.println("========================== Value for \"key\" (larger cluster): " + map1.get("key"));
+
+        System.out.println("========================== Map size (smaller cluster): " + map2.size());
+        System.out.println("========================== Value for \"key\" (smaller cluster): " + map2.get("key"));
+    }
+
+    @Override
+    void afterSplitBrain(HazelcastInstance[] instances) {
+        System.out.println("========================== Map size (merged cluster): " + map1.size());
+        System.out.println("========================== Value for \"key\" (merged cluster): " + map1.get("key"));
+
+        assertEquals(1, map1.size());
+        assertEquals(1, map2.size());
+
+        assertEquals("bigger-value", map1.get("key"));
+        assertEquals("bigger-value", map2.get("key"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        MapEntryCostsMapMergePolicyExample mergePolicyExample = new MapEntryCostsMapMergePolicyExample();
+        mergePolicyExample.run();
+    }
+}

--- a/spi/split-brain/src/main/java/MergeIntegerValuesMapMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/MergeIntegerValuesMapMergePolicyExample.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.MergeIntegerValuesMergePolicy;
+
+import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
+
+/**
+ * Shows the split-brain healing via the {@link MergeIntegerValuesMergePolicy}.
+ */
+public final class MergeIntegerValuesMapMergePolicyExample extends AbstractMapMergePolicyExample {
+
+    private MergeIntegerValuesMapMergePolicyExample() {
+        super(MergeIntegerValuesMergePolicy.class);
+    }
+
+    @Override
+    void duringSplitBrain(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        map1.put("key", "value");
+        map2.put("key", 42);
+
+        System.out.println("========================== Map size (larger cluster): " + map1.size());
+        System.out.println("========================== Value for \"key\" (larger cluster): " + map1.get("key"));
+
+        System.out.println("========================== Map size (smaller cluster): " + map2.size());
+        System.out.println("========================== Value for \"key\" (smaller cluster): " + map2.get("key"));
+    }
+
+    @Override
+    void afterSplitBrain(HazelcastInstance[] instances) {
+        System.out.println("========================== Map size (merged cluster): " + map1.size());
+        System.out.println("========================== Value for \"key\" (merged cluster): " + map1.get("key"));
+
+        assertEquals(1, map1.size());
+        assertEquals(1, map2.size());
+
+        assertEquals(42, map1.get("key"));
+        assertEquals(42, map2.get("key"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        MergeIntegerValuesMapMergePolicyExample mergePolicyExample = new MergeIntegerValuesMapMergePolicyExample();
+        mergePolicyExample.run();
+    }
+}

--- a/spi/split-brain/src/main/java/UserContextMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/UserContextMergePolicyExample.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.UserContextMergePolicy;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
+import static mergepolicies.UserContextMergePolicy.TRUTH_PROVIDER_ID;
+
+/**
+ * Shows the split-brain healing via the {@link UserContextMergePolicy}.
+ */
+public final class UserContextMergePolicyExample extends AbstractMapMergePolicyExample {
+
+    private UserContextMergePolicyExample() {
+        super(UserContextMergePolicy.class);
+    }
+
+    @Override
+    protected Config config() {
+        // we use the user context to provide access to our TruthProvider in the merge policy
+        ConcurrentMap<String, Object> userContext = new ConcurrentHashMap<String, Object>();
+        userContext.put(TRUTH_PROVIDER_ID, new ExampleTruthProvider());
+
+        return super.config()
+                .setUserContext(userContext);
+    }
+
+    @Override
+    void duringSplitBrain(HazelcastInstance[] firstBrain, HazelcastInstance[] secondBrain) {
+        map2.put("key1", 23);
+        map2.put("key2", 42);
+        map2.put("key3", 1337);
+
+        System.out.println("========================== Map size (larger cluster): " + map1.size());
+
+        System.out.println("========================== Map size (smaller cluster): " + map2.size());
+        System.out.println("========================== Value for \"key1\" (smaller cluster): " + map2.get("key1"));
+        System.out.println("========================== Value for \"key2\" (smaller cluster): " + map2.get("key2"));
+        System.out.println("========================== Value for \"key3\" (smaller cluster): " + map2.get("key3"));
+    }
+
+    @Override
+    void afterSplitBrain(HazelcastInstance[] instances) {
+        System.out.println("========================== Map size (merged cluster): " + map1.size());
+        System.out.println("========================== Value for \"key1\" (merged cluster): " + map1.get("key1"));
+        System.out.println("========================== Value for \"key2\" (merged cluster): " + map1.get("key2"));
+        System.out.println("========================== Value for \"key3\" (merged cluster): " + map1.get("key3"));
+
+        assertEquals(1, map1.size());
+        assertEquals(1, map2.size());
+
+        assertEquals(42, map1.get("key2"));
+        assertEquals(42, map2.get("key2"));
+    }
+
+    public static void main(String[] args) throws Exception {
+        UserContextMergePolicyExample mergePolicyExample = new UserContextMergePolicyExample();
+        mergePolicyExample.run();
+    }
+
+    private class ExampleTruthProvider implements UserContextMergePolicy.TruthProvider {
+
+        @Override
+        public boolean isMergeable(Object mergingValue, Object existingValue) {
+            return mergingValue instanceof Integer && (Integer) mergingValue == 42;
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/configvalidation/AtomicReferenceMergeIntegerValuesMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/configvalidation/AtomicReferenceMergeIntegerValuesMergePolicyExample.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configvalidation;
+
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.IAtomicReference;
+
+/**
+ * Shows that {@link mergepolicies.AtomicReferenceMergeIntegerValuesMergePolicy}
+ * just works on {@link IAtomicReference} data structures.
+ */
+public class AtomicReferenceMergeIntegerValuesMergePolicyExample {
+
+    public static void main(String[] args) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(mergepolicies.AtomicReferenceMergeIntegerValuesMergePolicy.class.getName());
+
+        MapConfig mapConfig = new MapConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        Config config = new Config()
+                .addMapConfig(mapConfig)
+                .addAtomicReferenceConfig(atomicReferenceConfig);
+
+        try {
+            HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+            // this works, since it's an IAtomicReference
+            hazelcastInstance.getAtomicReference("myAtomicReference");
+
+            try {
+                hazelcastInstance.getMap("myMap");
+            } catch (InvalidConfigurationException expected) {
+                System.out.println("The configured merge policy is just suitable for IAtomicReference: "
+                        + expected.getMessage());
+            }
+        } finally {
+            Hazelcast.shutdownAll();
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/configvalidation/CardinalityEstimatorExample.java
+++ b/spi/split-brain/src/main/java/configvalidation/CardinalityEstimatorExample.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configvalidation;
+
+import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.config.CardinalityEstimatorConfig;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MergePolicyConfig;
+import mergepolicies.MergeIntegerValuesMergePolicy;
+
+/**
+ * Shows that {@link CardinalityEstimator}
+ * doesn't support custom merge policies.
+ */
+public class CardinalityEstimatorExample {
+
+    public static void main(String[] args) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(MergeIntegerValuesMergePolicy.class.getName());
+
+        try {
+            new CardinalityEstimatorConfig("default")
+                    .setMergePolicyConfig(mergePolicyConfig);
+        } catch (InvalidConfigurationException e) {
+            System.out.println("The CardinalityEstimator doesn't allow custom merge policies: " + e.getMessage());
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/configvalidation/ComposedHitsAndCreationTimeExample.java
+++ b/spi/split-brain/src/main/java/configvalidation/ComposedHitsAndCreationTimeExample.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configvalidation;
+
+import com.hazelcast.config.AtomicLongConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.ComposedHitsAndCreationTimeMergePolicy;
+
+/**
+ * Shows that {@link ComposedHitsAndCreationTimeMergePolicy}
+ * just works on data structures which provide hit statistics.
+ */
+public class ComposedHitsAndCreationTimeExample {
+
+    public static void main(String[] args) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(ComposedHitsAndCreationTimeMergePolicy.class.getName());
+
+        ReplicatedMapConfig mapConfig = new ReplicatedMapConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        AtomicLongConfig atomicLongConfig = new AtomicLongConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        Config config = new Config()
+                .addReplicatedMapConfig(mapConfig)
+                .addAtomicLongConfig(atomicLongConfig);
+
+        try {
+            HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+            // this works, since ReplicatedMap provides hits and creation time
+            hazelcastInstance.getReplicatedMap("myReplicatedMap");
+
+            try {
+                hazelcastInstance.getAtomicLong("myAtomicLong");
+            } catch (InvalidConfigurationException expected) {
+                System.out.println("IAtomicLong doesn't provide the required hit statistics: " + expected.getMessage());
+            }
+        } finally {
+            Hazelcast.shutdownAll();
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/configvalidation/MapEntryCostsMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/configvalidation/MapEntryCostsMergePolicyExample.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configvalidation;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.config.InvalidConfigurationException;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.ReplicatedMapConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.MapEntryCostsMergePolicy;
+
+/**
+ * Shows that {@link MapEntryCostsMergePolicy}
+ * works on IMap data structures only.
+ */
+public class MapEntryCostsMergePolicyExample {
+
+    public static void main(String[] args) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(MapEntryCostsMergePolicy.class.getName());
+
+        MapConfig mapConfig = new MapConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        ReplicatedMapConfig replicatedMapConfig = new ReplicatedMapConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        Config config = new Config()
+                .addMapConfig(mapConfig)
+                .addReplicatedMapConfig(replicatedMapConfig);
+
+        try {
+            HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+            // this works, since it's an IMap
+            hazelcastInstance.getMap("myMap");
+
+            try {
+                hazelcastInstance.getReplicatedMap("myReplicatedMap");
+            } catch (InvalidConfigurationException expected) {
+                System.out.println("The configured merge policy is just suitable for IMap: " + expected.getMessage());
+            }
+        } finally {
+            Hazelcast.shutdownAll();
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/configvalidation/MergeIntegerValuesMergePolicyExample.java
+++ b/spi/split-brain/src/main/java/configvalidation/MergeIntegerValuesMergePolicyExample.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package configvalidation;
+
+import com.hazelcast.config.AtomicReferenceConfig;
+import com.hazelcast.config.Config;
+import com.hazelcast.config.MapConfig;
+import com.hazelcast.config.MergePolicyConfig;
+import com.hazelcast.config.ScheduledExecutorConfig;
+import com.hazelcast.core.Hazelcast;
+import com.hazelcast.core.HazelcastInstance;
+import mergepolicies.MergeIntegerValuesMergePolicy;
+
+/**
+ * Shows that {@link MergeIntegerValuesMergePolicy}
+ * works on all split-brain capable data structures.
+ */
+public class MergeIntegerValuesMergePolicyExample {
+
+    public static void main(String[] args) {
+        MergePolicyConfig mergePolicyConfig = new MergePolicyConfig()
+                .setPolicy(MergeIntegerValuesMergePolicy.class.getName());
+
+        MapConfig mapConfig = new MapConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        AtomicReferenceConfig atomicReferenceConfig = new AtomicReferenceConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        ScheduledExecutorConfig scheduledExecutorConfig = new ScheduledExecutorConfig("default")
+                .setMergePolicyConfig(mergePolicyConfig);
+
+        Config config = new Config()
+                .addMapConfig(mapConfig)
+                .addAtomicReferenceConfig(atomicReferenceConfig)
+                .addScheduledExecutorConfig(scheduledExecutorConfig);
+
+        try {
+            HazelcastInstance hazelcastInstance = Hazelcast.newHazelcastInstance(config);
+
+            // this works on all split-brain capable data structures, since MergingValue is provided by all of them
+            // (the only exception is the CardinalityEstimator, which doesn't allow custom merge policies)
+            hazelcastInstance.getMap("myMap");
+            hazelcastInstance.getAtomicReference("myAtomicReference");
+            hazelcastInstance.getScheduledExecutorService("myScheduledExecutor");
+        } finally {
+            Hazelcast.shutdownAll();
+        }
+    }
+}

--- a/spi/split-brain/src/main/java/mergepolicies/AtomicReferenceMergeIntegerValuesMergePolicy.java
+++ b/spi/split-brain/src/main/java/mergepolicies/AtomicReferenceMergeIntegerValuesMergePolicy.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mergepolicies;
+
+import com.hazelcast.core.IAtomicReference;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergeTypes.AtomicReferenceMergeTypes;
+
+/**
+ * Same merge policy as {@link MergeIntegerValuesMergePolicy},
+ * but limited to use with {@link IAtomicReference} data structures.
+ * <p>
+ * Even though all data structures provide the underlying {@link MergingValue},
+ * this merge policy will just work when configured with an {@link IAtomicReference},
+ * due to the required {@link AtomicReferenceMergeTypes}.
+ *
+ * @see com.hazelcast.spi.merge.SplitBrainMergeTypes
+ */
+public class AtomicReferenceMergeIntegerValuesMergePolicy implements SplitBrainMergePolicy<Data, AtomicReferenceMergeTypes> {
+
+    @Override
+    public Data merge(AtomicReferenceMergeTypes mergingValue, AtomicReferenceMergeTypes existingValue) {
+        // the in-memory format of the data structure maybe BINARY, but since we need to compare
+        // the real value, we have to use getDeserializedValue() instead of getValue()
+        Object mergingUserValue = mergingValue.getDeserializedValue();
+        Object existingUserValue = existingValue == null ? null : existingValue.getDeserializedValue();
+        System.out.println("========================== Merging..."
+                + "\n    mergingValue: " + mergingUserValue
+                + "\n    existingValue: " + existingUserValue
+                + "\n    mergingValue class: " + mergingUserValue.getClass().getName()
+                + "\n    existingValue class: " + (existingUserValue == null ? "null" : existingUserValue.getClass().getName())
+        );
+        if (mergingUserValue instanceof Integer) {
+            return mergingValue.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/spi/split-brain/src/main/java/mergepolicies/ComposedHitsAndCreationTimeMergePolicy.java
+++ b/spi/split-brain/src/main/java/mergepolicies/ComposedHitsAndCreationTimeMergePolicy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mergepolicies;
+
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.merge.MergingCreationTime;
+import com.hazelcast.spi.merge.MergingHits;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+/**
+ * Merge policy which shows composition of required merge types.
+ *
+ * @param <V> the type of the returned merged value
+ * @param <T> the type of the required merging value
+ * @see com.hazelcast.spi.merge.SplitBrainMergeTypes
+ */
+public class ComposedHitsAndCreationTimeMergePolicy<V, T extends MergingHits<V> & MergingCreationTime<V>>
+        implements SplitBrainMergePolicy<V, T> {
+
+    @Override
+    public V merge(T mergingValue, T existingValue) {
+        if (existingValue == null) {
+            return mergingValue.getValue();
+        }
+        System.out.println("========================== Merging value " + mergingValue.getDeserializedValue() + "..."
+                + "\n    mergingValue creation time: " + mergingValue.getCreationTime()
+                + "\n    existingValue creation time: " + existingValue.getCreationTime()
+                + "\n    mergingValue hits: " + mergingValue.getHits()
+                + "\n    existingValue hits: " + existingValue.getHits()
+        );
+        // the merging value wins, if it's older and has more hits
+        if (mergingValue.getCreationTime() < existingValue.getCreationTime()
+                && mergingValue.getHits() > existingValue.getHits()) {
+            return mergingValue.getValue();
+        }
+        return existingValue.getValue();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/spi/split-brain/src/main/java/mergepolicies/MapEntryCostsMergePolicy.java
+++ b/spi/split-brain/src/main/java/mergepolicies/MapEntryCostsMergePolicy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mergepolicies;
+
+import com.hazelcast.core.IMap;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.spi.merge.MergingCosts;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+import com.hazelcast.spi.merge.SplitBrainMergeTypes.MapMergeTypes;
+
+/**
+ * Merge policy which requires an {@link IMap} data structure.
+ * <p>
+ * Even if other data structures would provide the underlying {@link MergingCosts},
+ * this merge policy will just work when configured with an {@link IMap},
+ * due to the required {@link MapMergeTypes}.
+ *
+ * @see com.hazelcast.spi.merge.SplitBrainMergeTypes
+ */
+public class MapEntryCostsMergePolicy implements SplitBrainMergePolicy<Data, MapMergeTypes> {
+
+    @Override
+    public Data merge(MapMergeTypes mergingValue, MapMergeTypes existingValue) {
+        if (existingValue == null) {
+            return mergingValue.getValue();
+        }
+        System.out.println("========================== Merging key " + mergingValue.getDeserializedKey() + "..."
+                + "\n    mergingValue costs: " + mergingValue.getCost()
+                + "\n    existingValue costs: " + existingValue.getCost()
+        );
+        // the merging value wins, if it's costs are higher
+        if (mergingValue.getCost() > existingValue.getCost()) {
+            return mergingValue.getValue();
+        }
+        return existingValue.getValue();
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/spi/split-brain/src/main/java/mergepolicies/MergeIntegerValuesMergePolicy.java
+++ b/spi/split-brain/src/main/java/mergepolicies/MergeIntegerValuesMergePolicy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mergepolicies;
+
+import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+/**
+ * Simple merge policy, which only requires {@link MergingValue}.
+ * <p>
+ * This merge policy will work on all split-brain capable data structures
+ * (except {@link CardinalityEstimator}, which doesn't allow custom merge policies).
+ *
+ * @param <V> the type of the returned merged value
+ * @see com.hazelcast.spi.merge.SplitBrainMergeTypes
+ */
+public class MergeIntegerValuesMergePolicy<V> implements SplitBrainMergePolicy<V, MergingValue<V>> {
+
+    @Override
+    public V merge(MergingValue<V> mergingValue, MergingValue<V> existingValue) {
+        // the in-memory format of the data structure maybe BINARY, but since we need to compare
+        // the real value, we have to use getDeserializedValue() instead of getValue()
+        Object mergingUserValue = mergingValue.getDeserializedValue();
+        Object existingUserValue = existingValue == null ? null : existingValue.getDeserializedValue();
+        System.out.println("========================== Merging..."
+                + "\n    mergingValue: " + mergingUserValue
+                + "\n    existingValue: " + existingUserValue
+                + "\n    mergingValue class: " + mergingUserValue.getClass().getName()
+                + "\n    existingValue class: " + (existingUserValue == null ? "null" : existingUserValue.getClass().getName())
+        );
+        if (mergingUserValue instanceof Integer) {
+            return mergingValue.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+}

--- a/spi/split-brain/src/main/java/mergepolicies/UserContextMergePolicy.java
+++ b/spi/split-brain/src/main/java/mergepolicies/UserContextMergePolicy.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package mergepolicies;
+
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.core.HazelcastInstanceAware;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
+
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Merge policy which shows the usage of the user context.
+ *
+ * @param <V> the type of the returned merged value
+ * @see com.hazelcast.spi.merge.SplitBrainMergeTypes
+ */
+public class UserContextMergePolicy<V> implements SplitBrainMergePolicy<V, MergingValue<V>>, HazelcastInstanceAware {
+
+    public static final String TRUTH_PROVIDER_ID = "truthProvider";
+
+    private transient TruthProvider truthProvider;
+
+    @Override
+    public V merge(MergingValue<V> mergingValue, MergingValue<V> existingValue) {
+        // the in-memory format of the data structure maybe BINARY, but since we need to compare
+        // the real value, we have to use getDeserializedValue() instead of getValue()
+        Object mergingUserValue = mergingValue.getDeserializedValue();
+        Object existingUserValue = existingValue == null ? null : existingValue.getDeserializedValue();
+        boolean isMergeable = truthProvider.isMergeable(mergingUserValue, existingUserValue);
+        System.out.println("========================== Merging..."
+                + "\n    mergingValue: " + mergingUserValue
+                + "\n    existingValue: " + existingUserValue
+                + "\n    isMergeable(): " + isMergeable
+        );
+        if (isMergeable) {
+            return mergingValue.getValue();
+        }
+        return null;
+    }
+
+    @Override
+    public void writeData(ObjectDataOutput out) {
+    }
+
+    @Override
+    public void readData(ObjectDataInput in) {
+    }
+
+    @Override
+    public void setHazelcastInstance(HazelcastInstance hazelcastInstance) {
+        ConcurrentMap<String, Object> userContext = hazelcastInstance.getUserContext();
+        truthProvider = (TruthProvider) userContext.get(TRUTH_PROVIDER_ID);
+    }
+
+    public interface TruthProvider {
+
+        boolean isMergeable(Object mergingValue, Object existingValue);
+    }
+}


### PR DESCRIPTION
* ported `SplitBrainTestSupport` and `MergeBarrier` to the helper module
* ported `FireWallingConnectionManager` etc. classes to the helper module
* ported additional utility methods to the helper module
* added example for new merge policies

The `SplitBrainTestSupport` is not a 1:1 copy from the Hazelcast project, since we don't have the `TestHazelcastInstanceFactory` in the code samples. It's using the normal `HazelcastInstanceFactory` instead, but with a custom `FirewallingNodeContext`, to block and unblock the communication between nodes. It also doesn't provide a `createHazelcastInstanceInBrain(int brain)` method.

Nevertheless the code samples `SplitBrainTestSupport` is quite similar to the original, so it's very easy to convert existing split brain tests to code samples now.

Depends on https://github.com/hazelcast/hazelcast/pull/12573