### PR TITLE
Update PCF Manifest with mem: '512M' => '2G'

### DIFF
--- a/hazelcast-integration/pcf-integration/manifest.yml
+++ b/hazelcast-integration/pcf-integration/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
 - name: hazelcast-pcf-integration-test-app
-  memory: 512M
+  memory: 2G
   instances: 1
   path: target/pcf-integration-0.1-SNAPSHOT.jar


### PR DESCRIPTION
`512M` does not seem to be enough as the app fails with:

```
Memory available for allocation 512M is less than allocated memory 617208K (-XX:ReservedCodeCacheSize=240M, -XX:MaxDirectMemorySize=10M, -XX:MaxMetaspaceSize=105208K, -Xss1M * 250 threads)
```