### PR TITLE
Updates examples and docs to hibernate 5

### DIFF
--- a/hazelcast-integration/hibernate-2ndlevel-cache/README.md
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/README.md
@@ -14,11 +14,11 @@ By default `hibernate-core` added to project in `pom.xml` file as follows:
 <dependency>
     <groupId>org.hibernate</groupId>
     <artifactId>hibernate-core</artifactId>
-    <version>4.3.5.Final</version>
+    <version>5.0.9.Final</version>
 </dependency>
 ```
 
-But project is also compatible with hibernate 3.X.X versions. You can change these entries accordingly.
+But project is also compatible with hibernate 3.X.X and 4.X.XQ versions. You can change these entries accordingly.
 
 ## How to Run Sample Application
 
@@ -31,7 +31,7 @@ mvn compile
 2) Create database using:
 
 ```
-mvn exec:java -Dexec.mainClass="com.hazelcast.hibernate.CreateDB"
+mvn exec:java -Dexec.mainClass="com.hazelcast.hibernate.CreateTable"
 ```
 
 3) After running the following code, you can add or delete employees. Start with writing help in the application:

--- a/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
@@ -28,13 +28,13 @@
         </dependency>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-hibernate4</artifactId>
-            <version>3.6.4</version>
+            <artifactId>hazelcast-hibernate5</artifactId>
+            <version>1.2.3</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <version>4.3.8.Final</version>
+            <version>5.0.9.Final</version>
         </dependency>
         <dependency>
             <groupId>javassist</groupId>

--- a/hazelcast-integration/hibernate-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/ManageEmployee.java
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/src/main/java/com/hazelcast/hibernate/ManageEmployee.java
@@ -4,6 +4,7 @@ import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.resource.transaction.spi.TransactionStatus;
 
 import java.util.List;
 import java.util.Scanner;
@@ -89,11 +90,11 @@ public class ManageEmployee {
                 System.out.println("change       change between two sessions");
                 System.out.println("exit         exit");
             } else if (command.equals("exit")) {
-                if (!tx1.wasCommitted()) {
+                if (tx1.getStatus() != TransactionStatus.COMMITTED) {
                     tx1.commit();
                     session1.close();
                 }
-                if (!tx2.wasCommitted()) {
+                if (tx2.getStatus() != TransactionStatus.COMMITTED) {
                     tx2.commit();
                     session2.close();
                 }


### PR DESCRIPTION
Addressing https://github.com/hazelcast/hazelcast/issues/13250 I created PR https://github.com/hazelcast/hazelcast/pull/13861
Along with `hibernate-all` changing to hibernate 5 I updated the example.

The change from `CreateDB` to `CreateTable` is unrelated and seams to be a change that was not documented before.