### PR TITLE
Fix not building jib-maven-plugin

### DIFF
--- a/hazelcast-integration/aws-ecs/pom.xml
+++ b/hazelcast-integration/aws-ecs/pom.xml
@@ -74,6 +74,9 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>0.9.13</version>
+                <configuration>
+                    <allowInsecureRegistries>true</allowInsecureRegistries>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/hazelcast-integration/kubernetes/samples/embedded/pom.xml
+++ b/hazelcast-integration/kubernetes/samples/embedded/pom.xml
@@ -74,6 +74,9 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>0.9.13</version>
+                <configuration>
+                    <allowInsecureRegistries>true</allowInsecureRegistries>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Fixes the following issue which sometimes occurs while building the Docker image:
```
[ERROR] Failed to execute goal com.google.cloud.tools:jib-maven-plugin:0.9.13:build (default) on project jib-demo-project: Build image failed, perhaps you should use a registry that supports HTTPS or set the configuration parameter 'allowInsecureRegistries': Only secure connections are allowed, but tried to reach URL
```