### PR TITLE
Replace vulnerable spring-core dependency by a newer one

### DIFF
--- a/hazelcast-integration/spring-configuration/pom.xml
+++ b/hazelcast-integration/spring-configuration/pom.xml
@@ -23,7 +23,7 @@
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <spring.version>4.0.6.RELEASE</spring.version>
+        <spring.version>4.3.21.RELEASE</spring.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Several vulnerabilities were found in Spring Framework, let's switch to an up-to-date version.

https://www.cvedetails.com/vulnerability-list/vendor_id-15183/product_id-31286/Pivotal-Software-Spring-Framework.html