### PR TITLE
Add ignore for .java-version used by JEnv http://www.jenv.be/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bin/
 hibernateDB
 springHibernateDB
 osgi/felix-cache/
+.java-version


### PR DESCRIPTION
JEnv is a popular tool for managing java versions, it generates .java-version if you specify certain java versions related to a file path.