### PR TITLE
Adapt JCache code samples to changes in Hazelcast CachingProviders

### DIFF
--- a/enterprise/hidensity-cache/src/main/java/HiDensityCacheUsageSupport.java
+++ b/enterprise/hidensity-cache/src/main/java/HiDensityCacheUsageSupport.java
@@ -14,8 +14,10 @@ import com.hazelcast.memory.MemoryUnit;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
 
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.examples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
 /**
@@ -95,8 +97,9 @@ abstract class HiDensityCacheUsageSupport {
 
     static void init() {
         instance = createInstance(createConfig());
-        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(instance);
-        cacheManager = cachingProvider.getCacheManager();
+        CachingProvider cachingProvider = Caching.getCachingProvider(HazelcastServerCachingProvider.class.getName());
+        cacheManager = cachingProvider.getCacheManager(null, null,
+                propertiesByInstanceItself(instance));
     }
 
     static void destroy() {

--- a/enterprise/hot-restart/src/main/java/JCacheHotRestart.java
+++ b/enterprise/hot-restart/src/main/java/JCacheHotRestart.java
@@ -8,9 +8,12 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.IOUtil;
 
 import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
 import java.io.File;
 
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 import static com.hazelcast.examples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
 
 /**
@@ -55,13 +58,14 @@ public class JCacheHotRestart {
         Hazelcast.shutdownAll();
     }
 
-    private static Cache<Integer, String> createCache(HazelcastInstance instance) {
-        CachingProvider cachingProvider = HazelcastServerCachingProvider
-            .createCachingProvider(instance);
+    static Cache<Integer, String> createCache(HazelcastInstance instance) {
+        CachingProvider cachingProvider = Caching.getCachingProvider(HazelcastServerCachingProvider.class.getName());
+        CacheManager cacheManager = cachingProvider.getCacheManager(null, null,
+                propertiesByInstanceItself(instance));
 
         CacheConfig<Integer, String> cacheConfig = new CacheConfig<>("cache");
         cacheConfig.getHotRestartConfig().setEnabled(true);
 
-        return cachingProvider.getCacheManager().createCache("cache", cacheConfig);
+        return cacheManager.createCache("cache", cacheConfig);
     }
 }

--- a/enterprise/hot-restart/src/main/java/JCacheHotRestartEncryption.java
+++ b/enterprise/hot-restart/src/main/java/JCacheHotRestartEncryption.java
@@ -1,5 +1,3 @@
-import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.EncryptionAtRestConfig;
 import com.hazelcast.config.HotRestartPersistenceConfig;
@@ -10,7 +8,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.IOUtil;
 
 import javax.cache.Cache;
-import javax.cache.spi.CachingProvider;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
@@ -60,7 +57,7 @@ public class JCacheHotRestartEncryption {
 
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
 
-        Cache<Integer, String> cache = createCache(instance);
+        Cache<Integer, String> cache = JCacheHotRestart.createCache(instance);
         for (int i = 0; i < 10; i++) {
             cache.put(i, "value" + i);
         }
@@ -68,7 +65,7 @@ public class JCacheHotRestartEncryption {
         instance.shutdown();
 
         instance = Hazelcast.newHazelcastInstance(config);
-        cache = createCache(instance);
+        cache = JCacheHotRestart.createCache(instance);
 
         for (int i = 0; i < 10; i++) {
             System.out.println("cache.get(" + i + ") = " + cache.get(i));
@@ -90,15 +87,5 @@ public class JCacheHotRestartEncryption {
             ks.store(out, KEYSTORE_PASSWORD.toCharArray());
         }
         return new JavaKeyStoreSecureStoreConfig(keyStoreFile).setType(KEYSTORE_TYPE).setPassword(KEYSTORE_PASSWORD);
-    }
-
-    private static Cache<Integer, String> createCache(HazelcastInstance instance) {
-        CachingProvider cachingProvider = HazelcastServerCachingProvider
-                .createCachingProvider(instance);
-
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>("cache");
-        cacheConfig.getHotRestartConfig().setEnabled(true);
-
-        return cachingProvider.getCacheManager().createCache("cache", cacheConfig);
     }
 }

--- a/enterprise/hot-restart/src/main/java/JCacheHotRestartMultipleNodes.java
+++ b/enterprise/hot-restart/src/main/java/JCacheHotRestartMultipleNodes.java
@@ -1,6 +1,4 @@
-import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.JoinConfig;
@@ -9,7 +7,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.IOUtil;
 
 import javax.cache.Cache;
-import javax.cache.spi.CachingProvider;
 import java.io.File;
 
 import static com.hazelcast.examples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
@@ -30,7 +27,7 @@ public class JCacheHotRestartMultipleNodes {
         HazelcastInstance instance1 = newHazelcastInstance(5701);
         HazelcastInstance instance2 = newHazelcastInstance(5702);
 
-        Cache<Integer, String> cache = createCache(instance1);
+        Cache<Integer, String> cache = JCacheHotRestart.createCache(instance1);
         for (int i = 0; i < 50; i++) {
             cache.put(i, "value" + i);
         }
@@ -45,7 +42,7 @@ public class JCacheHotRestartMultipleNodes {
         instance2 = newHazelcastInstance(5702);
         instance2.getCluster().changeClusterState(ClusterState.ACTIVE);
 
-        cache = createCache(instance2);
+        cache = JCacheHotRestart.createCache(instance2);
         for (int i = 0; i < 50; i++) {
             System.out.println("cache.get(" + i + ") = " + cache.get(i));
         }
@@ -68,15 +65,5 @@ public class JCacheHotRestartMultipleNodes {
         hotRestartConfig.setEnabled(true).setBaseDir(new File(HOT_RESTART_ROOT_DIR + port));
 
         return Hazelcast.newHazelcastInstance(config);
-    }
-
-    private static Cache<Integer, String> createCache(HazelcastInstance instance) {
-        CachingProvider cachingProvider = HazelcastServerCachingProvider
-            .createCachingProvider(instance);
-
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>("cache");
-        cacheConfig.getHotRestartConfig().setEnabled(true);
-
-        return cachingProvider.getCacheManager().createCache("cache", cacheConfig);
     }
 }

--- a/enterprise/hot-restart/src/main/java/JCacheRollingRestart.java
+++ b/enterprise/hot-restart/src/main/java/JCacheRollingRestart.java
@@ -1,6 +1,4 @@
-import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.cluster.ClusterState;
-import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.config.HotRestartPersistenceConfig;
 import com.hazelcast.config.JoinConfig;
@@ -9,7 +7,6 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.internal.nio.IOUtil;
 
 import javax.cache.Cache;
-import javax.cache.spi.CachingProvider;
 import java.io.File;
 
 import static com.hazelcast.examples.helper.LicenseUtils.ENTERPRISE_LICENSE_KEY;
@@ -30,7 +27,7 @@ public class JCacheRollingRestart {
         HazelcastInstance instance1 = newHazelcastInstance(5701);
         HazelcastInstance instance2 = newHazelcastInstance(5702);
 
-        Cache<Integer, String> cache = createCache(instance2);
+        Cache<Integer, String> cache = JCacheHotRestart.createCache(instance2);
         for (int i = 0; i < 50; i++) {
             cache.put(i, "value" + i);
         }
@@ -65,15 +62,5 @@ public class JCacheRollingRestart {
         hotRestartConfig.setEnabled(true).setBaseDir(new File(HOT_RESTART_ROOT_DIR + port));
 
         return Hazelcast.newHazelcastInstance(config);
-    }
-
-    private static Cache<Integer, String> createCache(HazelcastInstance instance) {
-        CachingProvider cachingProvider = HazelcastServerCachingProvider
-            .createCachingProvider(instance);
-
-        CacheConfig<Integer, String> cacheConfig = new CacheConfig<>("cache");
-        cacheConfig.getHotRestartConfig().setEnabled(true);
-
-        return cachingProvider.getCacheManager().createCache("cache", cacheConfig);
     }
 }

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -19,19 +19,13 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
 
         <jsr107.api.version>1.0.0</jsr107.api.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-client</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>

--- a/jcache/src/main/java/com/hazelcast/examples/SimpleCacheTest.java
+++ b/jcache/src/main/java/com/hazelcast/examples/SimpleCacheTest.java
@@ -26,11 +26,15 @@ import com.hazelcast.logging.ILogger;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.Caching;
 import javax.cache.configuration.MutableConfiguration;
+import javax.cache.spi.CachingProvider;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
+
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 
 /**
  * A simple benchmark test for JCache.
@@ -137,8 +141,9 @@ public final class SimpleCacheTest {
     }
 
     private void run(ExecutorService es) {
-        HazelcastServerCachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(instance);
-        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CachingProvider cachingProvider = Caching.getCachingProvider(HazelcastServerCachingProvider.class.getName());
+        CacheManager cacheManager = cachingProvider.getCacheManager(null, null,
+                propertiesByInstanceItself(instance));
 
         // configure the cache
         MutableConfiguration<String, Object> config = new MutableConfiguration<String, Object>();

--- a/jcache/src/main/java/com/hazelcast/examples/instance/JCacheThroughHazelcastInstanceExample.java
+++ b/jcache/src/main/java/com/hazelcast/examples/instance/JCacheThroughHazelcastInstanceExample.java
@@ -11,7 +11,10 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.core.ICacheManager;
 
 import javax.cache.CacheManager;
+import javax.cache.Caching;
 import javax.cache.spi.CachingProvider;
+
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 
 /**
  * Demonstrates how to use JCache through `HazelcastInstance` rather than Hazelcast's `CacheManager`.
@@ -23,8 +26,9 @@ public class JCacheThroughHazelcastInstanceExample {
     public static void main(String[] args) {
         Config config = new Config().addCacheConfig(createCacheSimpleConfig(BASE_CACHE_NAME + "_1"));
         HazelcastInstance instance = Hazelcast.newHazelcastInstance(config);
-        CachingProvider cachingProvider = HazelcastServerCachingProvider.createCachingProvider(instance);
-        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CachingProvider cachingProvider = Caching.getCachingProvider(HazelcastServerCachingProvider.class.getName());
+        CacheManager cacheManager = cachingProvider.getCacheManager(null, null,
+                propertiesByInstanceItself(instance));
 
         // ICacheManager is Hazelcast-specific interface, not to be confused with JCache's CacheManager.
         // An instance of the ICacheManager can be obtained from a HazelcastInstance and used to get

--- a/jcache/src/main/java/com/hazelcast/examples/listener/PartitionLostListenerUsage.java
+++ b/jcache/src/main/java/com/hazelcast/examples/listener/PartitionLostListenerUsage.java
@@ -2,8 +2,6 @@ package com.hazelcast.examples.listener;
 
 import com.hazelcast.cache.ICache;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
-import com.hazelcast.cache.impl.event.CachePartitionLostEvent;
-import com.hazelcast.cache.impl.event.CachePartitionLostListener;
 import com.hazelcast.config.CacheConfig;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
@@ -11,9 +9,11 @@ import com.hazelcast.core.HazelcastInstance;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
+import javax.cache.Caching;
+import javax.cache.spi.CachingProvider;
 import java.util.concurrent.CountDownLatch;
 
-import static com.hazelcast.cache.impl.HazelcastServerCachingProvider.createCachingProvider;
+import static com.hazelcast.cache.HazelcastCachingProvider.propertiesByInstanceItself;
 
 public class PartitionLostListenerUsage {
 
@@ -27,10 +27,11 @@ public class PartitionLostListenerUsage {
         HazelcastInstance serverInstance1 = Hazelcast.newHazelcastInstance(new Config());
         HazelcastInstance serverInstance2 = Hazelcast.newHazelcastInstance(new Config());
 
-        HazelcastServerCachingProvider cachingProvider = createCachingProvider(serverInstance1);
-        CacheManager cacheManager = cachingProvider.getCacheManager();
+        CachingProvider cachingProvider = Caching.getCachingProvider(HazelcastServerCachingProvider.class.getName());
+        CacheManager cacheManager = cachingProvider.getCacheManager(null, null,
+                propertiesByInstanceItself(serverInstance1));
 
-        CacheConfig<Integer, String> config1 = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> config1 = new CacheConfig<>();
         // might lose data if any node crashes
         config1.setBackupCount(0);
         Cache<Integer, String> cache1 = cacheManager.createCache(cacheName1, config1);
@@ -38,15 +39,12 @@ public class PartitionLostListenerUsage {
         cache1.put(1, "Berlin");
 
         ICache iCache1 = cache1.unwrap(ICache.class);
-        iCache1.addPartitionLostListener(new CachePartitionLostListener() {
-            @Override
-            public void partitionLost(CachePartitionLostEvent cachePartitionLostEvent) {
-                System.out.println(cachePartitionLostEvent);
-                latch.countDown();
-            }
+        iCache1.addPartitionLostListener(cachePartitionLostEvent -> {
+            System.out.println(cachePartitionLostEvent);
+            latch.countDown();
         });
 
-        CacheConfig<Integer, String> config2 = new CacheConfig<Integer, String>();
+        CacheConfig<Integer, String> config2 = new CacheConfig<>();
         // keeps its data if a single node crashes
         config2.setBackupCount(1);
         Cache<Integer, String> cache2 = cacheManager.createCache(cacheName2, config2);
@@ -54,12 +52,8 @@ public class PartitionLostListenerUsage {
         cache1.put(1, "Berlin");
 
         ICache iCache2 = cache2.unwrap(ICache.class);
-        iCache2.addPartitionLostListener(new CachePartitionLostListener() {
-            @Override
-            public void partitionLost(CachePartitionLostEvent cachePartitionLostEvent) {
-                System.err.println("This line should not be printed! " + cachePartitionLostEvent);
-            }
-        });
+        iCache2.addPartitionLostListener(
+                cachePartitionLostEvent -> System.err.println("This line should not be printed! " + cachePartitionLostEvent));
 
         System.out.println("Terminating second Hazelcast instance...");
         serverInstance2.getLifecycleService().terminate();

--- a/jcache/src/main/java/com/hazelcast/examples/splitbrain/custom/AbstractCacheSplitBrainSampleWithCustomCacheMergePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/splitbrain/custom/AbstractCacheSplitBrainSampleWithCustomCacheMergePolicy.java
@@ -1,14 +1,14 @@
 package com.hazelcast.examples.splitbrain.custom;
 
-import com.hazelcast.nio.ObjectDataInput;
-import com.hazelcast.nio.ObjectDataOutput;
-import com.hazelcast.spi.merge.MergingValue;
-import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 import com.hazelcast.cache.impl.HazelcastServerCachingProvider;
 import com.hazelcast.config.Config;
 import com.hazelcast.core.Hazelcast;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.examples.splitbrain.AbstractCacheSplitBrainSample;
+import com.hazelcast.nio.ObjectDataInput;
+import com.hazelcast.nio.ObjectDataOutput;
+import com.hazelcast.spi.merge.MergingValue;
+import com.hazelcast.spi.merge.SplitBrainMergePolicy;
 
 import javax.cache.Cache;
 import javax.cache.CacheManager;
@@ -22,9 +22,16 @@ import static com.hazelcast.examples.helper.CommonUtils.assertTrue;
 import static com.hazelcast.examples.helper.HazelcastUtils.generateKeyOwnedBy;
 
 /**
- * Base class for jcache split-brain sample based on `custom cache merge policy.
+ * Base class for jcache split-brain sample based on custom cache merge policy.
  *
  * Custom cache merge policy implements {@link com.hazelcast.spi.merge.SplitBrainMergePolicy} and handles its own logic.
+ * <p>
+ * <b>IMPORTANT</b>: this sample uses internal API {@code HazelcastServerCachingProvider} to
+ * start two separate {@code CachingProvider}s and associated {@code CacheManager}s with separate
+ * backing {@link HazelcastInstance}s. Application production code should never do that. Instead
+ * use JCache standard API methods as described in javadoc of {@link com.hazelcast.cache.HazelcastCachingProvider}
+ * or public Hazelcast API.
+ * </p>
  */
 abstract class AbstractCacheSplitBrainSampleWithCustomCacheMergePolicy extends AbstractCacheSplitBrainSample {
 
@@ -42,8 +49,8 @@ abstract class AbstractCacheSplitBrainSampleWithCustomCacheMergePolicy extends A
 
             CountDownLatch splitBrainCompletedLatch = simulateSplitBrain(h1, h2);
 
-            CachingProvider cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(h1);
-            CachingProvider cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(h2);
+            CachingProvider cachingProvider1 = new HazelcastServerCachingProvider(h1);
+            CachingProvider cachingProvider2 = new HazelcastServerCachingProvider(h2);
 
             CacheManager cacheManager1 = cachingProvider1.getCacheManager();
             CacheManager cacheManager2 = cachingProvider2.getCacheManager();

--- a/jcache/src/main/java/com/hazelcast/examples/splitbrain/higherhits/AbstractCacheSplitBrainSampleWithHigherHitsCacheMergePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/splitbrain/higherhits/AbstractCacheSplitBrainSampleWithHigherHitsCacheMergePolicy.java
@@ -16,10 +16,17 @@ import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
 import static com.hazelcast.examples.helper.CommonUtils.assertOpenEventually;
 
 /**
- * Base class for jcache split-brain sample based on `HIGHER_HITS` cache merge policy.
+ * Base class for jcache split-brain sample based on {@code HIGHER_HITS} cache merge policy.
  *
- * `HIGHER_HITS` cache merge policy merges cache entry from source to destination cache
+ * {@code HIGHER_HITS} cache merge policy merges cache entry from source to destination cache
  * if source entry has more hits than the destination one.
+ * <p>
+ * <b>IMPORTANT</b>: this sample uses internal API {@code HazelcastServerCachingProvider} to
+ * start two separate {@code CachingProvider}s and associated {@code CacheManager}s with separate
+ * backing {@link HazelcastInstance}s. Application production code should never do that. Instead
+ * use JCache standard API methods as described in javadoc of {@link com.hazelcast.cache.HazelcastCachingProvider}
+ * or public Hazelcast API.
+ * </p>
  */
 abstract class AbstractCacheSplitBrainSampleWithHigherHitsCacheMergePolicy extends AbstractCacheSplitBrainSample {
 
@@ -37,8 +44,8 @@ abstract class AbstractCacheSplitBrainSampleWithHigherHitsCacheMergePolicy exten
 
             CountDownLatch splitBrainCompletedLatch = simulateSplitBrain(h1, h2);
 
-            CachingProvider cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(h1);
-            CachingProvider cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(h2);
+            CachingProvider cachingProvider1 = new HazelcastServerCachingProvider(h1);
+            CachingProvider cachingProvider2 = new HazelcastServerCachingProvider(h2);
 
             CacheManager cacheManager1 = cachingProvider1.getCacheManager();
             CacheManager cacheManager2 = cachingProvider2.getCacheManager();

--- a/jcache/src/main/java/com/hazelcast/examples/splitbrain/latestaccess/AbstractCacheSplitBrainSampleWithLatestAccessCacheMergePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/splitbrain/latestaccess/AbstractCacheSplitBrainSampleWithLatestAccessCacheMergePolicy.java
@@ -17,10 +17,17 @@ import static com.hazelcast.examples.helper.CommonUtils.assertOpenEventually;
 import static com.hazelcast.examples.helper.CommonUtils.sleepAtLeastMillis;
 
 /**
- * Base class for jcache split-brain sample based on `LATEST_ACCESS` cache merge policy.
+ * Base class for jcache split-brain sample based on {@code LATEST_ACCESS} cache merge policy.
  *
- * `LATEST_ACCESS` cache merge policy merges cache entry from source to destination cache
+ * {@code LATEST_ACCESS} cache merge policy merges cache entry from source to destination cache
  * if source entry has been accessed more recently than the destination entry.
+ * <p>
+ * <b>IMPORTANT</b>: this sample uses internal API {@code HazelcastServerCachingProvider} to
+ * start two separate {@code CachingProvider}s and associated {@code CacheManager}s with separate
+ * backing {@link HazelcastInstance}s. Application production code should never do that. Instead
+ * use JCache standard API methods as described in javadoc of {@link com.hazelcast.cache.HazelcastCachingProvider}
+ * or public Hazelcast API.
+ * </p>
  */
 abstract class AbstractCacheSplitBrainSampleWithLatestAccessCacheMergePolicy extends AbstractCacheSplitBrainSample {
 
@@ -38,8 +45,8 @@ abstract class AbstractCacheSplitBrainSampleWithLatestAccessCacheMergePolicy ext
 
             CountDownLatch splitBrainCompletedLatch = simulateSplitBrain(h1, h2);
 
-            CachingProvider cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(h1);
-            CachingProvider cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(h2);
+            CachingProvider cachingProvider1 = new HazelcastServerCachingProvider(h1);
+            CachingProvider cachingProvider2 = new HazelcastServerCachingProvider(h2);
 
             CacheManager cacheManager1 = cachingProvider1.getCacheManager();
             CacheManager cacheManager2 = cachingProvider2.getCacheManager();

--- a/jcache/src/main/java/com/hazelcast/examples/splitbrain/passthrough/AbstractCacheSplitBrainSampleWithPassThroughCacheMergePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/splitbrain/passthrough/AbstractCacheSplitBrainSampleWithPassThroughCacheMergePolicy.java
@@ -17,10 +17,17 @@ import static com.hazelcast.examples.helper.CommonUtils.assertOpenEventually;
 import static com.hazelcast.examples.helper.HazelcastUtils.generateKeyOwnedBy;
 
 /**
- * Base class for jcache split-brain sample based on `PASS_THROUGH` cache merge policy.
+ * Base class for jcache split-brain sample based on {@code PASS_THROUGH} cache merge policy.
  *
- * `PASS_THROUGH` cache merge policy merges cache entry from source to destination
+ * {@code PASS_THROUGH} cache merge policy merges cache entry from source to destination
  * if it does not exist in the destination cache.
+ * <p>
+ * <b>IMPORTANT</b>: this sample uses internal API {@code HazelcastServerCachingProvider} to
+ * start two separate {@code CachingProvider}s and associated {@code CacheManager}s with separate
+ * backing {@link HazelcastInstance}s. Application production code should never do that. Instead
+ * use JCache standard API methods as described in javadoc of {@link com.hazelcast.cache.HazelcastCachingProvider}
+ * or public Hazelcast API.
+ * </p>
  */
 abstract class AbstractCacheSplitBrainSampleWithPassThroughCacheMergePolicy extends AbstractCacheSplitBrainSample {
 
@@ -38,8 +45,8 @@ abstract class AbstractCacheSplitBrainSampleWithPassThroughCacheMergePolicy exte
 
             CountDownLatch splitBrainCompletedLatch = simulateSplitBrain(h1, h2);
 
-            CachingProvider cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(h1);
-            CachingProvider cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(h2);
+            CachingProvider cachingProvider1 = new HazelcastServerCachingProvider(h1);
+            CachingProvider cachingProvider2 = new HazelcastServerCachingProvider(h2);
 
             CacheManager cacheManager1 = cachingProvider1.getCacheManager();
             CacheManager cacheManager2 = cachingProvider2.getCacheManager();

--- a/jcache/src/main/java/com/hazelcast/examples/splitbrain/putifabsent/AbstractCacheSplitBrainSampleWithPutIfAbsentCacheMergePolicy.java
+++ b/jcache/src/main/java/com/hazelcast/examples/splitbrain/putifabsent/AbstractCacheSplitBrainSampleWithPutIfAbsentCacheMergePolicy.java
@@ -16,9 +16,15 @@ import static com.hazelcast.examples.helper.CommonUtils.assertEquals;
 import static com.hazelcast.examples.helper.CommonUtils.assertOpenEventually;
 
 /**
- * Base class for jcache split-brain sample based on `PUT_IF_ABSENT` cache merge policy.
- *
- * `PASS_THROUGH` cache merge policy merges cache entry from source to destination directly.
+ * Base class for jcache split-brain sample based on {@code PUT_IF_ABSENT} cache merge policy.
+ * {@code PASS_THROUGH} cache merge policy merges cache entry from source to destination directly.
+ * <p>
+ * <b>IMPORTANT</b>: this sample uses internal API {@code HazelcastServerCachingProvider} to
+ * start two separate {@code CachingProvider}s and associated {@code CacheManager}s with separate
+ * backing {@link HazelcastInstance}s. Application production code should never do that. Instead
+ * use JCache standard API methods as described in javadoc of {@link com.hazelcast.cache.HazelcastCachingProvider}
+ * or public Hazelcast API.
+ * </p>
  */
 abstract class AbstractCacheSplitBrainSampleWithPutIfAbsentCacheMergePolicy extends AbstractCacheSplitBrainSample {
 
@@ -36,8 +42,8 @@ abstract class AbstractCacheSplitBrainSampleWithPutIfAbsentCacheMergePolicy exte
 
             CountDownLatch splitBrainCompletedLatch = simulateSplitBrain(h1, h2);
 
-            CachingProvider cachingProvider1 = HazelcastServerCachingProvider.createCachingProvider(h1);
-            CachingProvider cachingProvider2 = HazelcastServerCachingProvider.createCachingProvider(h2);
+            CachingProvider cachingProvider1 = new HazelcastServerCachingProvider(h1);
+            CachingProvider cachingProvider2 = new HazelcastServerCachingProvider(h2);
 
             CacheManager cacheManager1 = cachingProvider1.getCacheManager();
             CacheManager cacheManager2 = cachingProvider2.getCacheManager();


### PR DESCRIPTION
- Previously public static factories have been removed and specific
Hazelcast server/client caching provider classes are private API.
Code samples are adapted to use public API where possible. In some
cases (eg split-brain code samples) it is impossible to use public
API; usage of private API methods is explicitly indicated in code
samples' javadoc
-  Default caching provider returned by Caching.getCachingProvider
is client-side caching provider. In order to obtain a server-side
caching provider, user has to explicitly request for that by
class name.