### PR TITLE
Fixes problem with tcp renaming in core.

### DIFF
--- a/helper/src/main/java/com/hazelcast/examples/helper/CommonUtils.java
+++ b/helper/src/main/java/com/hazelcast/examples/helper/CommonUtils.java
@@ -18,7 +18,6 @@ package com.hazelcast.examples.helper;
 
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.instance.impl.HazelcastInstanceProxy;
-import com.hazelcast.internal.nio.EndpointManager;
 import com.hazelcast.internal.util.EmptyStatement;
 import com.hazelcast.internal.util.ExceptionUtil;
 
@@ -28,7 +27,6 @@ import java.lang.reflect.Field;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 
-import static com.hazelcast.examples.helper.HazelcastUtils.getNode;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -161,12 +159,9 @@ public final class CommonUtils {
     public static void assertClusterSize(int expectedSize, HazelcastInstance instance) {
         int clusterSize = instance.getCluster().getMembers().size();
         if (expectedSize != clusterSize) {
-            EndpointManager endpointManager = getNode(instance).getEndpointManager();
-            int activeConnectionCount = endpointManager.getActiveConnections().size();
-            throw new AssertionError(String.format("Cluster size is not correct. Expected: %d Actual: %d %s",
+            throw new AssertionError(String.format("Cluster size is not correct. Expected: %d Actual: %d",
                     expectedSize,
-                    clusterSize,
-                    "ActiveConnectionCount: " + activeConnectionCount));
+                    clusterSize));
         }
     }
 


### PR DESCRIPTION
I simplified the assert because the assert was broken.

It can happen if 2 node start concurrently that you get more than 1
connection. So you can do much with connection count in the first place.