### PR TITLE
Replace fabric8-maven-plugin dependency with Eclipse JKube OpensShift Maven Plugin

### DIFF
--- a/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
@@ -1,6 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>ocp-demo-frontend</artifactId>
@@ -22,17 +20,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-kubernetes</artifactId>
-            <version>1.0.0</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
 
         <dependency>
             <groupId>com.hazelcast.samples.openshift.client-apps</groupId>
@@ -100,11 +87,10 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>io.fabric8</groupId>
-                <artifactId>fabric8-maven-plugin</artifactId>
-                <version>3.5.37</version>
+                <groupId>org.eclipse.jkube</groupId>
+                <artifactId>openshift-maven-plugin</artifactId>
+                <version>1.0.0-rc-1</version>
                 <configuration>
-                    <buildStrategy>docker</buildStrategy>
                     <generator>
                         <includes>
                             <include>spring-boot</include>

--- a/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/src/main/fabric8/deployment.yml
+++ b/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/src/main/fabric8/deployment.yml
@@ -1,7 +1,0 @@
-spec:
-  template:
-    spec:
-      containers:
-        ports:
-          - containerPort: 8080
-            protocol: TCP


### PR DESCRIPTION
[Fabric8 Maven Plugin](https://github.com/fabric8io/fabric8-maven-plugin) (FMP) will be deprecated soon, [Eclipse JKube](https://github.com/eclipse/jkube) should be used instead.

Eclipse JKube 1.0.0-rc-1 was recently released, and as part of the core maintainer team, we need feedback from the community to see if current projects depending on FMP can be easily upgraded to use JKube. As part of the strategy to seek this feedback we are creating PRs on those repositories which we know are currently using FMP.

The current PR replaces the plugin dependency for FMP to Eclipse JKube and updates the README steps accordingly.

- Image is no longer built with Docker, default OpenShift S2I build strategy is used instead (can be switched back to Docker if necessary).
  - This prevents the user from having any problems regarding pushing the image to the cluster (since the image will be actually built in the cluster).
  - No Docker Daemon is required in order to perform the build
- Deployment is performed using Eclipse JKube's Maven specific goals:
  - `oc:resource`: is used to generate resource manifests with the required cluster configuration (deploymentconfig, service, route)
  - `oc:apply`: is used to apply the generated manifests to the cluster and perform the deployment

These changes should also take care of #388