### PR TITLE
Do not use deprecated methods of ObjectDataInput/Output, PortableRead…

### DIFF
--- a/distributed-map/custom-attributes/src/main/java/com/test/portable/Limb.java
+++ b/distributed-map/custom-attributes/src/main/java/com/test/portable/Limb.java
@@ -35,12 +35,12 @@ public class Limb implements Portable {
 
     @Override
     public void writePortable(PortableWriter out) throws IOException {
-        out.writeUTF("name", name);
+        out.writeString("name", name);
     }
 
     @Override
     public void readPortable(PortableReader in) throws IOException {
-        name = in.readUTF("name");
+        name = in.readString("name");
     }
 
 }

--- a/distributed-map/custom-attributes/src/main/java/com/test/portable/Person.java
+++ b/distributed-map/custom-attributes/src/main/java/com/test/portable/Person.java
@@ -38,13 +38,13 @@ public class Person implements Portable {
 
     @Override
     public void writePortable(PortableWriter out) throws IOException {
-        out.writeUTF("name", name);
+        out.writeString("name", name);
         out.writePortableArray("limbs", limbs);
     }
 
     @Override
     public void readPortable(PortableReader in) throws IOException {
-        name = in.readUTF("name");
+        name = in.readString("name");
         limbs = in.readPortableArray("limbs");
     }
 }

--- a/distributed-map/query-collections/src/main/java/com/test/query/QueryCollectionsPortableDemo.java
+++ b/distributed-map/query-collections/src/main/java/com/test/query/QueryCollectionsPortableDemo.java
@@ -67,13 +67,13 @@ public class QueryCollectionsPortableDemo {
 
         @Override
         public void writePortable(PortableWriter out) throws IOException {
-            out.writeUTF("name", name);
+            out.writeString("name", name);
             out.writePortableArray("limbs", limbs);
         }
 
         @Override
         public void readPortable(PortableReader in) throws IOException {
-            name = in.readUTF("name");
+            name = in.readString("name");
             limbs = in.readPortableArray("limbs");
         }
     }
@@ -107,12 +107,12 @@ public class QueryCollectionsPortableDemo {
 
         @Override
         public void writePortable(PortableWriter out) throws IOException {
-            out.writeUTF("name", name);
+            out.writeString("name", name);
         }
 
         @Override
         public void readPortable(PortableReader in) throws IOException {
-            name = in.readUTF("name");
+            name = in.readString("name");
         }
     }
 

--- a/generic-record/generic-record-client/src/main/java/example/AddQuantityEntryProcessor.java
+++ b/generic-record/generic-record-client/src/main/java/example/AddQuantityEntryProcessor.java
@@ -22,17 +22,18 @@ public class AddQuantityEntryProcessor implements Serializable, EntryProcessor {
     @Override
     public Object process(Map.Entry entry) {
         GenericRecord genericRecord = (GenericRecord) entry.getValue();
-        String name = genericRecord.readUTF("name");
+        String name = genericRecord.getString("name");
         if (!name.equals(productName)) {
             return null;
         }
 
-        int quantity = genericRecord.readInt("quantity");
+        int quantity = genericRecord.getInt("quantity");
         quantity += additionalQuantity;
 
         GenericRecord newRecord = genericRecord.newBuilder()
-                .writeUTF("name", name)
-                .writeInt("quantity", quantity).build();
+                .setString("name", name)
+                .setInt("quantity", quantity)
+                .build();
 
         entry.setValue(newRecord);
         return null;

--- a/generic-record/generic-record-client/src/main/java/example/ClientWithoutDomainObjectExample.java
+++ b/generic-record/generic-record-client/src/main/java/example/ClientWithoutDomainObjectExample.java
@@ -7,43 +7,49 @@ import com.hazelcast.map.IMap;
 import com.hazelcast.nio.serialization.ClassDefinition;
 import com.hazelcast.nio.serialization.ClassDefinitionBuilder;
 import com.hazelcast.nio.serialization.GenericRecord;
+import com.hazelcast.nio.serialization.GenericRecordBuilder;
 
-import java.io.IOException;
 import java.util.Collection;
 
 import static com.hazelcast.query.Predicates.sql;
 
 public class ClientWithoutDomainObjectExample {
 
-    public static void main(String[] args) throws IOException {
-        ClassDefinition classDefinition = new ClassDefinitionBuilder(1, 2).addUTFField("name").addIntField("age").build();
+    public static void main(String[] args) {
+        ClassDefinition classDefinition = new ClassDefinitionBuilder(1, 2)
+                .addStringField("name")
+                .addIntField("age")
+                .build();
 
         ClientConfig clientConfig = new ClientConfig();
         HazelcastInstance client = HazelcastClient.newHazelcastClient(clientConfig);
 
         IMap<Integer, Object> map = client.getMap("products");
 
-        GenericRecord wally = GenericRecord.Builder.portable(classDefinition)
-                .writeUTF("name", "Wally")
-                .writeInt("age", 30).build();
+        GenericRecord wally = GenericRecordBuilder.portable(classDefinition)
+                .setString("name", "Wally")
+                .setInt("age", 30)
+                .build();
 
         map.put(1, wally);
 
-        GenericRecord kermit = GenericRecord.Builder.portable(classDefinition)
-                .writeUTF("name", "Kermit The Frog")
-                .writeInt("age", 12).build();
+        GenericRecord kermit = GenericRecordBuilder.portable(classDefinition)
+                .setString("name", "Kermit The Frog")
+                .setInt("age", 12)
+                .build();
 
         map.put(2, kermit);
 
         Collection<Object> values = map.values(sql("age > 10"));
 
-        //prints
+        // prints
         // Kermit The Frog
         // Wally
         for (Object value : values) {
             GenericRecord record = (GenericRecord) value;
-            System.out.println(record.readUTF("name"));
+            System.out.println(record.getString("name"));
         }
 
+        client.shutdown();
     }
 }

--- a/generic-record/generic-record-client/src/main/java/example/ProcessAll.java
+++ b/generic-record/generic-record-client/src/main/java/example/ProcessAll.java
@@ -27,7 +27,7 @@ public class ProcessAll implements HazelcastInstanceAware, Serializable, Callabl
             if (poll == null) {
                 break;
             }
-            int quantity = poll.readInt("quantity");
+            int quantity = poll.getInt("quantity");
             totalNumberOfItems += quantity;
         }
         return totalNumberOfItems;

--- a/generic-record/generic-record-client/src/main/java/example/Product.java
+++ b/generic-record/generic-record-client/src/main/java/example/Product.java
@@ -31,13 +31,13 @@ public class Product implements Portable {
 
     @Override
     public void writePortable(PortableWriter writer) throws IOException {
-        writer.writeUTF("name", name);
+        writer.writeString("name", name);
         writer.writeInt("quantity", quantity);
     }
 
     @Override
     public void readPortable(PortableReader reader) throws IOException {
-        name = reader.readUTF("name");
+        name = reader.readString("name");
         quantity = reader.readInt("quantity");
     }
 

--- a/jcache/src/main/java/com/hazelcast/examples/jcache/client/PortableDomainObjectExample.java
+++ b/jcache/src/main/java/com/hazelcast/examples/jcache/client/PortableDomainObjectExample.java
@@ -82,14 +82,14 @@ public class PortableDomainObjectExample extends AbstractApp {
         @Override
         public void writePortable(PortableWriter portableWriter) throws IOException {
             System.out.println("Writing portable");
-            portableWriter.writeUTF("name", name);
+            portableWriter.writeString("name", name);
             portableWriter.writeLong("id", id);
         }
 
         @Override
         public void readPortable(PortableReader portableReader) throws IOException {
             System.out.println("Reading portable");
-            name = portableReader.readUTF("name");
+            name = portableReader.readString("name");
             id = portableReader.readLong("id");
         }
 

--- a/near-cache/fraud-detection/fraud-detection-common/src/main/java/com/hazelcast/samples/nearcache/frauddetection/User.java
+++ b/near-cache/fraud-detection/fraud-detection-common/src/main/java/com/hazelcast/samples/nearcache/frauddetection/User.java
@@ -30,14 +30,14 @@ public class User implements DataSerializable {
     @Override
     public void writeData(ObjectDataOutput objectDataOutput) throws IOException {
         objectDataOutput.writeInt(this.userId);
-        objectDataOutput.writeUTF(this.lastCardUsePlace);
+        objectDataOutput.writeString(this.lastCardUsePlace);
         objectDataOutput.writeLong(this.lastCardUseTimestamp);
     }
 
     @Override
     public void readData(ObjectDataInput objectDataInput) throws IOException {
         this.userId = objectDataInput.readInt();
-        this.lastCardUsePlace = objectDataInput.readUTF();
+        this.lastCardUsePlace = objectDataInput.readString();
         this.lastCardUseTimestamp = objectDataInput.readLong();
     }
 }

--- a/org-website-samples/src/main/java/client/IdentifiedDataSerializableSample.java
+++ b/org-website-samples/src/main/java/client/IdentifiedDataSerializableSample.java
@@ -22,13 +22,13 @@ public class IdentifiedDataSerializableSample {
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             id = in.readInt();
-            name = in.readUTF();
+            name = in.readString();
         }
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(id);
-            out.writeUTF(name);
+            out.writeString(name);
         }
 
         @Override

--- a/org-website-samples/src/main/java/client/PortableSerializableSample.java
+++ b/org-website-samples/src/main/java/client/PortableSerializableSample.java
@@ -32,14 +32,14 @@ public class PortableSerializableSample {
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeInt("id", id);
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writeLong("lastOrder", lastOrder.getTime());
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
             id = reader.readInt("id");
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             lastOrder = new Date(reader.readLong("lastOrder"));
         }
     }

--- a/org-website-samples/src/main/java/client/QuerySample.java
+++ b/org-website-samples/src/main/java/client/QuerySample.java
@@ -54,14 +54,14 @@ public class QuerySample {
 
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
-            writer.writeUTF("username", username);
+            writer.writeString("username", username);
             writer.writeInt("age", age);
             writer.writeBoolean("active", active);
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
-            username = reader.readUTF("username");
+            username = reader.readString("username");
             age = reader.readInt("age");
             active = reader.readBoolean("active");
         }

--- a/org-website-samples/src/main/java/member/IdentifiedDataSerializableSample.java
+++ b/org-website-samples/src/main/java/member/IdentifiedDataSerializableSample.java
@@ -22,13 +22,13 @@ public class IdentifiedDataSerializableSample {
         @Override
         public void readData(ObjectDataInput in) throws IOException {
             id = in.readInt();
-            name = in.readUTF();
+            name = in.readString();
         }
 
         @Override
         public void writeData(ObjectDataOutput out) throws IOException {
             out.writeInt(id);
-            out.writeUTF(name);
+            out.writeString(name);
         }
 
         @Override

--- a/org-website-samples/src/main/java/member/PortableSerializableSample.java
+++ b/org-website-samples/src/main/java/member/PortableSerializableSample.java
@@ -32,14 +32,14 @@ public class PortableSerializableSample {
         @Override
         public void writePortable(PortableWriter writer) throws IOException {
             writer.writeInt("id", id);
-            writer.writeUTF("name", name);
+            writer.writeString("name", name);
             writer.writeLong("lastOrder", lastOrder.getTime());
         }
 
         @Override
         public void readPortable(PortableReader reader) throws IOException {
             id = reader.readInt("id");
-            name = reader.readUTF("name");
+            name = reader.readString("name");
             lastOrder = new Date(reader.readLong("lastOrder"));
         }
     }

--- a/serialization/data-serializable/src/main/java/Person.java
+++ b/serialization/data-serializable/src/main/java/Person.java
@@ -18,12 +18,12 @@ public class Person implements DataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.name = in.readUTF();
+        this.name = in.readString();
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override

--- a/serialization/global-serializer/src/main/java/PersonStreamSerializer.java
+++ b/serialization/global-serializer/src/main/java/PersonStreamSerializer.java
@@ -17,11 +17,11 @@ public class PersonStreamSerializer implements StreamSerializer<Person> {
 
     @Override
     public void write(ObjectDataOutput out, Person object) throws IOException {
-        out.writeUTF(object.getName());
+        out.writeString(object.getName());
     }
 
     @Override
     public Person read(ObjectDataInput in) throws IOException {
-        return new Person(in.readUTF());
+        return new Person(in.readString());
     }
 }

--- a/serialization/identified-data-serializable/src/main/java/Person.java
+++ b/serialization/identified-data-serializable/src/main/java/Person.java
@@ -17,12 +17,12 @@ public class Person implements IdentifiedDataSerializable {
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        this.name = in.readUTF();
+        this.name = in.readString();
     }
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(name);
+        out.writeString(name);
     }
 
     @Override

--- a/serialization/portable/src/main/java/Person.java
+++ b/serialization/portable/src/main/java/Person.java
@@ -28,13 +28,13 @@ public class Person implements Portable {
     @Override
     public void writePortable(PortableWriter writer) throws IOException {
         System.out.println("Serialize");
-        writer.writeUTF("name", name);
+        writer.writeString("name", name);
     }
 
     @Override
     public void readPortable(PortableReader reader) throws IOException {
         System.out.println("Deserialize");
-        this.name = reader.readUTF("name");
+        this.name = reader.readString("name");
     }
 
     @Override

--- a/serialization/stream-serializer/src/main/java/CarStreamSerializer.java
+++ b/serialization/stream-serializer/src/main/java/CarStreamSerializer.java
@@ -14,13 +14,13 @@ public class CarStreamSerializer implements StreamSerializer<Car> {
     @Override
     public void write(ObjectDataOutput out, Car car) throws IOException {
         out.writeObject(car.getOwner());
-        out.writeUTF(car.getColor());
+        out.writeString(car.getColor());
     }
 
     @Override
     public Car read(ObjectDataInput in) throws IOException {
         Person owner = in.readObject();
-        String color = in.readUTF();
+        String color = in.readString();
         return new Car(owner, color);
     }
 

--- a/serialization/stream-serializer/src/main/java/PersonStreamSerializer.java
+++ b/serialization/stream-serializer/src/main/java/PersonStreamSerializer.java
@@ -13,12 +13,12 @@ public class PersonStreamSerializer implements StreamSerializer<Person> {
 
     @Override
     public void write(ObjectDataOutput out, Person object) throws IOException {
-        out.writeUTF(object.getName());
+        out.writeString(object.getName());
     }
 
     @Override
     public Person read(ObjectDataInput in) throws IOException {
-        String name = in.readUTF();
+        String name = in.readString();
         return new Person(name);
     }
 

--- a/spi/tenant-control/src/main/java/multitenant/MultiTenantControl.java
+++ b/spi/tenant-control/src/main/java/multitenant/MultiTenantControl.java
@@ -55,11 +55,11 @@ public class MultiTenantControl implements TenantControl {
 
     @Override
     public void writeData(ObjectDataOutput out) throws IOException {
-        out.writeUTF(cacheName);
+        out.writeString(cacheName);
     }
 
     @Override
     public void readData(ObjectDataInput in) throws IOException {
-        cacheName = in.readUTF();
+        cacheName = in.readString();
     }
 }


### PR DESCRIPTION
…er/Writer, and ClassDefinitionBuilder

We have deprecated methods containing `UTF` in their names and
introduced new methods that contain `String` instead of it in https://github.com/hazelcast/hazelcast/pull/18100.

This is a cleanup PR to use newly introduced methods instead of the
deprecated ones. The change is done automatically via IDE and
verified manually by going over the changes.

Also, fixed compilation errors due to the changes in the GenericRecords.