### PR TITLE
Bump Eclipse JKube OpenShift Maven Plugin to 1.3.0

### DIFF
--- a/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
@@ -89,7 +89,7 @@
             <plugin>
                 <groupId>org.eclipse.jkube</groupId>
                 <artifactId>openshift-maven-plugin</artifactId>
-                <version>1.0.0-rc-1</version>
+                <version>1.3.0</version>
                 <configuration>
                     <generator>
                         <includes>


### PR DESCRIPTION
Updated Eclipse JKube (org.eclipse.jkube:openshift-maven-plugin) to latest stable version.

Tested with [hazelcast-cluster/hazelcast/hazelcast.yaml](https://github.com/marcnuri-forks/hazelcast-code-samples/blob/ed762d74899a3f26474670ad932ad18e26df0f78/hazelcast-integration/openshift/hazelcast-cluster/hazelcast/hazelcast.yaml) template, CRC 1.26 and OpenShift v4.7.8.

Relates to #452 