### PR TITLE
Use JDK 8 for serialization/benchmark

### DIFF
--- a/serialization/benchmarks/pom.xml
+++ b/serialization/benchmarks/pom.xml
@@ -26,7 +26,7 @@
 
 		<avro.version>1.10.2</avro.version>
 		<grpc.version>1.36.0</grpc.version>
-		<java.version>11</java.version>
+		<java.version>8</java.version>
 		<javax.annotation-api.version>1.3.2</javax.annotation-api.version>
 		<jmh.version>1.28</jmh.version>
 		<kryo.version>5.0.4</kryo.version>


### PR DESCRIPTION
Fix for serialization/benchmark cannot be compiled with JDK 8:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile (default-compile) on project serialization-benchmarks-common: Fatal error compiling: invalid target release: 11 -> [Help 1]
```