### PR TITLE
Jet samples fixes 

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,7 +19,6 @@
     <suppress checks="VisibilityModifierCheck" files="client/*" />
     <suppress checks="VisibilityModifierCheck" files="jet/cdc/Customer" />
     <suppress checks="VisibilityModifierCheck" files="jet/files/SalesJsonAnalyzer" />
-    <suppress checks="VisibilityModifierCheck" files="jet/files/unifiedapi/Trade" />
     <suppress checks="EmptyBlock" files="member/LockSample" />
     <suppress checks="EmptyBlock" files="client/LockSample" />
     <suppress checks="InnerAssignment" files="jet/jobmanagement/JobSuspendResume" />

--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -19,6 +19,7 @@
     <suppress checks="VisibilityModifierCheck" files="client/*" />
     <suppress checks="VisibilityModifierCheck" files="jet/cdc/Customer" />
     <suppress checks="VisibilityModifierCheck" files="jet/files/SalesJsonAnalyzer" />
+    <suppress checks="VisibilityModifierCheck" files="jet/files/unifiedapi/Trade" />
     <suppress checks="EmptyBlock" files="member/LockSample" />
     <suppress checks="EmptyBlock" files="client/LockSample" />
     <suppress checks="InnerAssignment" files="jet/jobmanagement/JobSuspendResume" />

--- a/jet/cdc/src/main/java/com/hazelcast/samples/jet/cdc/Cache.java
+++ b/jet/cdc/src/main/java/com/hazelcast/samples/jet/cdc/Cache.java
@@ -45,7 +45,7 @@ import com.hazelcast.jet.pipeline.StreamSource;
  * </pre>
  * <p>
  * The map written into by this pipeline's sink can be read from other Jet jobs
- * or IMDG clients as any other {@code IMap}.
+ * or Hazelcast clients as any other {@code IMap}.
  */
 public class Cache {
 

--- a/jet/event-journal/src/main/java/com/hazelcast/samples/jet/eventjournal/CacheJournalSource.java
+++ b/jet/event-journal/src/main/java/com/hazelcast/samples/jet/eventjournal/CacheJournalSource.java
@@ -34,7 +34,7 @@ import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDES
 /**
  * A pipeline which streams events from an ICache. The
  * values for new entries are extracted and then written
- * to a local IList in the Jet cluster.
+ * to a local IList in the Hazelcast cluster.
  */
 public class CacheJournalSource {
 

--- a/jet/files/src/main/java/com/hazelcast/samples/jet/files/unifiedapi/Trade.java
+++ b/jet/files/src/main/java/com/hazelcast/samples/jet/files/unifiedapi/Trade.java
@@ -32,11 +32,10 @@ import java.util.Objects;
  */
 public class Trade implements Serializable {
 
-    // they need to be public since they are accessed from field mappers
-    public long time;
-    public String ticker;
-    public long quantity;
-    public long price;
+    private long time;
+    private String ticker;
+    private long quantity;
+    private long price;
 
     public Trade() {
     }
@@ -76,6 +75,36 @@ public class Trade implements Serializable {
      */
     public long getPrice() {
         return price;
+    }
+
+    // these setters are accessed from the field mappers
+
+    /**
+     * Set the event time of the trade.
+     */
+    public void setTime(long time) {
+        this.time = time;
+    }
+
+    /**
+     * Set the name of the trade instrument.
+     */
+    public void setTicker(String ticker) {
+        this.ticker = ticker;
+    }
+
+    /**
+     * Set the quantity of the trade.
+     */
+    public void setQuantity(long quantity) {
+        this.quantity = quantity;
+    }
+
+    /**
+     * Set the price of trade.
+     */
+    public void setPrice(long price) {
+        this.price = price;
     }
 
     @Override

--- a/jet/files/src/main/java/com/hazelcast/samples/jet/files/unifiedapi/Trade.java
+++ b/jet/files/src/main/java/com/hazelcast/samples/jet/files/unifiedapi/Trade.java
@@ -32,10 +32,11 @@ import java.util.Objects;
  */
 public class Trade implements Serializable {
 
-    private long time;
-    private String ticker;
-    private long quantity;
-    private long price;
+    // they need to be public since they are accessed from field mappers
+    public long time;
+    public String ticker;
+    public long quantity;
+    public long price;
 
     public Trade() {
     }

--- a/jet/job-management/src/main/java/com/hazelcast/samples/jet/jobmanagement/JobTracking.java
+++ b/jet/job-management/src/main/java/com/hazelcast/samples/jet/jobmanagement/JobTracking.java
@@ -32,7 +32,7 @@ import static com.hazelcast.jet.pipeline.JournalInitialPosition.START_FROM_OLDES
 import static java.util.Objects.requireNonNull;
 
 /**
- * We demonstrate how submitted jobs can be fetched and tracked via any Jet
+ * We demonstrate how submitted jobs can be fetched and tracked via any Hazelcast
  * instance.
  */
 public class JobTracking {
@@ -57,7 +57,7 @@ public class JobTracking {
         jet1.newJob(p, jobConfig);
 
         JetService jet2 = hz2.getJet();
-        // jobs can be also tracked via other Jet nodes
+        // jobs can be also tracked via other Hazelcast members
         List<Job> jobs = jet2.getJobs();
         Job trackedJob1 = jobs.get(0);
 

--- a/jet/tf-idf/src/main/java/com/hazelcast/samples/jet/tfidf/TfIdf.java
+++ b/jet/tf-idf/src/main/java/com/hazelcast/samples/jet/tfidf/TfIdf.java
@@ -178,7 +178,7 @@ public class TfIdf {
     }
 
     private void go() {
-        System.out.println("Creating Jet instance 1");
+        System.out.println("Creating Hazelcast instance 1");
         hz = Hazelcast.bootstrappedInstance();
         buildInvertedIndex();
         System.out.println("size=" + hz.getMap(INVERTED_INDEX).size());

--- a/json/jsongrid/jsongrid-client-java/src/main/java/com/hazelcast/samples/json/jsongrid/ApplicationRunner.java
+++ b/json/jsongrid/jsongrid-client-java/src/main/java/com/hazelcast/samples/json/jsongrid/ApplicationRunner.java
@@ -154,7 +154,6 @@ public class ApplicationRunner implements CommandLineRunner {
 
         Collection<?> results =
                 iMap.values(Predicates.sql(sql));
-
         for (Object result : results) {
             System.out.println(result);
         }


### PR DESCRIPTION
This pr remove Jet instance mentions from couple of javadocs and json field mapping issue in files
which I accidentally created while porting code samples. 
