### PR TITLE
Remove hazelcast all usages from demos

### DIFF
--- a/cluster-state/pom.xml
+++ b/cluster-state/pom.xml
@@ -23,7 +23,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/cp-subsystem/pom.xml
+++ b/cp-subsystem/pom.xml
@@ -48,7 +48,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -22,8 +22,13 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jline</groupId>
+            <artifactId>jline</artifactId>
+            <version>${jline.version}</version>
         </dependency>
     </dependencies>
 

--- a/demo/src/main/resources/clientConsole.bat
+++ b/demo/src/main/resources/clientConsole.bat
@@ -1,1 +1,1 @@
-java -cp ../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.client.console.ClientConsoleApp
+java -cp ../target/lib/hazelcast-${hazelcast.version}.jar;../target/lib/jline-${jline.version}.jar com.hazelcast.client.console.ClientConsoleApp

--- a/demo/src/main/resources/clientConsole.sh
+++ b/demo/src/main/resources/clientConsole.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -Djava.net.preferIPv4Stack=true -cp ../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.client.console.ClientConsoleApp
+java -Djava.net.preferIPv4Stack=true -cp ../target/lib/hazelcast-${hazelcast.version}.jar:../target/lib/jline-${jline.version}.jar com.hazelcast.client.console.ClientConsoleApp

--- a/demo/src/main/resources/console.bat
+++ b/demo/src/main/resources/console.bat
@@ -1,1 +1,1 @@
-java -cp ../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.console.ConsoleApp
+java -cp ../target/lib/hazelcast-${hazelcast.version}.jar com.hazelcast.console.ConsoleApp

--- a/demo/src/main/resources/console.sh
+++ b/demo/src/main/resources/console.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -Djava.net.preferIPv4Stack=true -cp ../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.console.ConsoleApp
+java -Djava.net.preferIPv4Stack=true -cp ../target/lib/hazelcast-${hazelcast.version}.jar com.hazelcast.console.ConsoleApp

--- a/demo/src/main/resources/simpleMapTest.bat
+++ b/demo/src/main/resources/simpleMapTest.bat
@@ -1,1 +1,1 @@
-java -server -cp ../target/demo-${project.version}.jar;../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.demo.SimpleMapTest %1 %2 %3 %4 %5 %6
+java -server -cp ../target/demo-${project.version}.jar;../target/lib/hazelcast-${hazelcast.version}.jar com.hazelcast.demo.SimpleMapTest %1 %2 %3 %4 %5 %6

--- a/demo/src/main/resources/simpleMapTest.sh
+++ b/demo/src/main/resources/simpleMapTest.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-java -server -Djava.net.preferIPv4Stack=true -cp ../target/demo-${project.version}.jar:../target/lib/hazelcast-all-${hazelcast.version}.jar com.hazelcast.demo.SimpleMapTest $@
+java -server -Djava.net.preferIPv4Stack=true -cp ../target/demo-${project.version}.jar:../target/lib/hazelcast-${hazelcast.version}.jar com.hazelcast.demo.SimpleMapTest $@

--- a/distributed-collections/pom.xml
+++ b/distributed-collections/pom.xml
@@ -37,7 +37,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/distributed-executor/pom.xml
+++ b/distributed-executor/pom.xml
@@ -45,7 +45,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/distributed-map/pom.xml
+++ b/distributed-map/pom.xml
@@ -55,7 +55,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/distributed-primitives/pom.xml
+++ b/distributed-primitives/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/distributed-topic/pom.xml
+++ b/distributed-topic/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/pom.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/pom.xml
@@ -23,11 +23,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-enterprise</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
             <version>1.1.1</version>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/pom.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/pom.xml
@@ -23,11 +23,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-enterprise</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-        <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
             <version>1.1.1</version>

--- a/enterprise/hd-memory-client-server/pom.xml
+++ b/enterprise/hd-memory-client-server/pom.xml
@@ -7,8 +7,8 @@
     <artifactId>hd-memory-client-server</artifactId>
     <name>Enterprise - HD Memory Client / Server</name>
     <description>
-        Demonstrates Hazelcast HD Memory
-        by running a small heap JVM cluster server and referencing 3gb of native memory.
+        Demonstrates Hazelcast HD Memory by running a small heap
+        JVM cluster server and referencing 3 GB of native memory.
     </description>
 
     <parent>

--- a/enterprise/hidensity-cache/pom.xml
+++ b/enterprise/hidensity-cache/pom.xml
@@ -33,10 +33,5 @@
             <artifactId>jcache</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-enterprise</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
     </dependencies>
 </project>

--- a/enterprise/ldap-authentication/pom.xml
+++ b/enterprise/ldap-authentication/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.jline</groupId>
             <artifactId>jline-reader</artifactId>
-            <version>3.19.0</version>
+            <version>${jline.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/enterprise/pcf-tls-integration/pom.xml
+++ b/enterprise/pcf-tls-integration/pom.xml
@@ -42,24 +42,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-
-        <dependency>
-
-            <groupId>com.hazelcast.samples</groupId>
-            <artifactId>helper</artifactId>
-            <version>${project.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>com.hazelcast</groupId>
-                    <artifactId>hazelcast-all</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
             <version>${spring-boot.version}</version>

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -63,7 +63,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-enterprise-all</artifactId>
+            <artifactId>hazelcast-enterprise</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
         <dependency>

--- a/generic-record/pom.xml
+++ b/generic-record/pom.xml
@@ -21,7 +21,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
@@ -26,11 +26,6 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast</artifactId>
-            <version>${hazelcast.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-hibernate53</artifactId>
             <version>${hazelcast.hibernate.version}</version>
         </dependency>

--- a/hazelcast-integration/pom.xml
+++ b/hazelcast-integration/pom.xml
@@ -57,7 +57,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/hazelcast-integration/spring-data-hazelcast-chemistry-sample/client/pom.xml
+++ b/hazelcast-integration/spring-data-hazelcast-chemistry-sample/client/pom.xml
@@ -21,6 +21,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-client</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>

--- a/hazelcast-integration/springaware-annotation/pom.xml
+++ b/hazelcast-integration/springaware-annotation/pom.xml
@@ -22,6 +22,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-core</artifactId>
             <version>${spring.version}</version>

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -22,8 +22,9 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -22,7 +22,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -36,7 +36,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-all</artifactId>
+			<artifactId>hazelcast</artifactId>
 			<version>${hazelcast.version}</version>
 		</dependency>
 

--- a/learning-basics/pom.xml
+++ b/learning-basics/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/near-cache/pom.xml
+++ b/near-cache/pom.xml
@@ -36,7 +36,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-all</artifactId>
+			<artifactId>hazelcast</artifactId>
 			<version>${hazelcast.version}</version>
 		</dependency>
 

--- a/network-configuration/pom.xml
+++ b/network-configuration/pom.xml
@@ -40,7 +40,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
 

--- a/org-website-samples/pom.xml
+++ b/org-website-samples/pom.xml
@@ -35,7 +35,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
         <dependency>

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -25,7 +25,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
         <hazelcast.version>5.1-SNAPSHOT</hazelcast.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
 
+        <!-- Used in ClientConsole application-->
+        <jline.version>3.19.0</jline.version>
         <!--Used in jet code samples-->
         <jsr107.api.version>1.0.0</jsr107.api.version>
         <avro.version>1.10.2</avro.version>

--- a/querying/pom.xml
+++ b/querying/pom.xml
@@ -36,7 +36,7 @@
 	<dependencies>
 		<dependency>
 			<groupId>com.hazelcast</groupId>
-			<artifactId>hazelcast-all</artifactId>
+			<artifactId>hazelcast</artifactId>
 			<version>${hazelcast.version}</version>
 		</dependency>
 

--- a/replicated-map/pom.xml
+++ b/replicated-map/pom.xml
@@ -33,7 +33,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/serialization/pom.xml
+++ b/serialization/pom.xml
@@ -46,7 +46,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -32,7 +32,7 @@
     <dependencies>
         <dependency>
             <groupId>com.hazelcast</groupId>
-            <artifactId>hazelcast-all</artifactId>
+            <artifactId>hazelcast</artifactId>
             <version>${hazelcast.version}</version>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This pr removes all `hazelcast-all` artifact usages from demos 
except one demo using the 3.x version of hazelcast in particular.