### PR TITLE
Update Kafka examples

### DIFF
--- a/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/TopicUtil.java
+++ b/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/TopicUtil.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazelcast.samples.jet.kafka;
+
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+
+import java.io.Closeable;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+public class TopicUtil implements Closeable {
+    private final Admin admin;
+
+    public TopicUtil(String broker) {
+        Properties props = new Properties();
+        props.setProperty("bootstrap.servers", broker);
+        admin = Admin.create(props);
+    }
+
+    public void createTopic(String topicId, int partitionCount) {
+        List<NewTopic> newTopics = Collections.singletonList(new NewTopic(topicId, partitionCount, (short) 1));
+        CreateTopicsResult createTopicsResult = admin.createTopics(newTopics);
+        try {
+            createTopicsResult.all().get();
+        } catch (InterruptedException | ExecutionException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void close() {
+        admin.close();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <parquet.version>1.12.0</parquet.version>
         <scala.version>2.12</scala.version>
         <zookeeper.version>3.5.8</zookeeper.version>
-        <kafka.version>2.2.2</kafka.version>
+        <kafka.version>2.8.1</kafka.version>
         <grpc.version>1.34.0</grpc.version>
         <protobuf.version>3.13.0</protobuf.version>
         <maven.os.plugin.version>1.6.2</maven.os.plugin.version>


### PR DESCRIPTION
Update code samples to work with the updated Kafka connector (with Kafka 2.8.1 dependencies)

### Testing

I've run the following samples:
```
mvn compile exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.hazelcast.samples.jet.kafka.KafkaSink -pl jet/kafka
mvn compile exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.hazelcast.samples.jet.kafka.KafkaSource -pl jet/kafka
mvn compile exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.hazelcast.samples.jet.kafka.avro.KafkaAvroSource -pl jet/kafka
mvn compile exec:java -Dexec.cleanupDaemonThreads=false -Dexec.mainClass=com.hazelcast.samples.jet.kafka.json.KafkaJsonSource -pl jet/kafka
```