### PR TITLE
Close kafka consumer before shutting down Kafka server

### DIFF
--- a/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSink.java
+++ b/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSink.java
@@ -165,8 +165,8 @@ public class KafkaSink {
     }
 
     private void shutdownKafkaCluster() {
-        kafkaServer.shutdown();
         kafkaConsumer.close();
+        kafkaServer.shutdown();
         zkServer.shutdown();
     }
 


### PR DESCRIPTION
Close Kafka consumer before shutting down Kafka server to avoid the following log entries at the end of the run:
```
[Consumer clientId=consumer0, groupId=verification-consumer] Connection to node 0 (localhost/127.0.0.1:9092) could not be established. Broker may not be available.
```