### PR TITLE
Use String values in Kafka samples to make them readable in Confluent Control Center UI

### DIFF
--- a/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSink.java
+++ b/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSink.java
@@ -34,8 +34,6 @@ import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Time;
@@ -64,7 +62,7 @@ public class KafkaSink {
 
     private EmbeddedZookeeper zkServer;
     private KafkaServer kafkaServer;
-    private KafkaConsumer<String, Integer> kafkaConsumer;
+    private KafkaConsumer<String, String> kafkaConsumer;
 
     private static Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
@@ -72,7 +70,7 @@ public class KafkaSink {
          .writeTo(KafkaSinks.kafka(props(
                          "bootstrap.servers", BOOTSTRAP_SERVERS,
                          "key.serializer", StringSerializer.class.getCanonicalName(),
-                         "value.serializer", IntegerSerializer.class.getCanonicalName()),
+                         "value.serializer", StringSerializer.class.getCanonicalName()),
                  SINK_TOPIC_NAME));
         return p;
     }
@@ -90,7 +88,7 @@ public class KafkaSink {
             HazelcastInstance hz = Hazelcast.bootstrappedInstance();
             JetService jet = hz.getJet();
 
-            IMap<String, Integer> sourceMap = hz.getMap(SOURCE_NAME);
+            IMap<String, String> sourceMap = hz.getMap(SOURCE_NAME);
             fillIMap(sourceMap);
 
 
@@ -124,8 +122,8 @@ public class KafkaSink {
         }
     }
 
-    public KafkaConsumer<String, Integer> createConsumer(String... topicIds) {
-        return createConsumer(StringDeserializer.class, IntegerDeserializer.class, emptyMap(), topicIds);
+    public KafkaConsumer<String, String> createConsumer(String... topicIds) {
+        return createConsumer(StringDeserializer.class, StringDeserializer.class, emptyMap(), topicIds);
     }
 
     public <K, V> KafkaConsumer<K, V> createConsumer(
@@ -164,10 +162,10 @@ public class KafkaSink {
         kafkaServer = TestUtils.createServer(config, mock);
     }
 
-    private void fillIMap(IMap<String, Integer> sourceMap) {
+    private void fillIMap(IMap<String, String> sourceMap) {
         LOGGER.info("Filling IMap");
         for (int i = 1; i <= MESSAGE_COUNT; i++) {
-            sourceMap.put("t1-" + i, i);
+            sourceMap.put("t1-" + i, String.valueOf(i));
         }
         LOGGER.info("Published " + MESSAGE_COUNT + " messages to IMap -> " + SOURCE_NAME);
     }

--- a/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSource.java
+++ b/jet/kafka/src/main/java/com/hazelcast/samples/jet/kafka/KafkaSource.java
@@ -33,8 +33,6 @@ import kafka.utils.TestUtils;
 import kafka.zk.EmbeddedZookeeper;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.common.serialization.IntegerDeserializer;
-import org.apache.kafka.common.serialization.IntegerSerializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Time;
@@ -66,10 +64,10 @@ public class KafkaSource {
     private static Pipeline buildPipeline() {
         Pipeline p = Pipeline.create();
         p.readFrom(KafkaSources.kafka(props(
-                "bootstrap.servers", BOOTSTRAP_SERVERS,
-                "key.deserializer", StringDeserializer.class.getCanonicalName(),
-                "value.deserializer", IntegerDeserializer.class.getCanonicalName(),
-                "auto.offset.reset", AUTO_OFFSET_RESET)
+                                "bootstrap.servers", BOOTSTRAP_SERVERS,
+                                "key.deserializer", StringDeserializer.class.getCanonicalName(),
+                                "value.deserializer", StringDeserializer.class.getCanonicalName(),
+                                "auto.offset.reset", AUTO_OFFSET_RESET)
                 , "t1", "t2"))
          .withoutTimestamps()
          .writeTo(Sinks.map(SINK_NAME));
@@ -91,7 +89,7 @@ public class KafkaSource {
 
             HazelcastInstance hz = Hazelcast.bootstrappedInstance();
             JetService jet = hz.getJet();
-            IMap<String, Integer> sinkMap = hz.getMap(SINK_NAME);
+            IMap<String, String> sinkMap = hz.getMap(SINK_NAME);
 
             Pipeline p = buildPipeline();
 
@@ -144,11 +142,11 @@ public class KafkaSource {
         Properties props = props(
                 "bootstrap.servers", "localhost:9092",
                 "key.serializer", StringSerializer.class.getName(),
-                "value.serializer", IntegerSerializer.class.getName());
-        try (KafkaProducer<String, Integer> producer = new KafkaProducer<>(props)) {
+                "value.serializer", StringSerializer.class.getName());
+        try (KafkaProducer<String, String> producer = new KafkaProducer<>(props)) {
             for (int i = 1; i <= MESSAGE_COUNT_PER_TOPIC; i++) {
-                producer.send(new ProducerRecord<>("t1", "t1-" + i, i));
-                producer.send(new ProducerRecord<>("t2", "t2-" + i, i));
+                producer.send(new ProducerRecord<>("t1", "t1-" + i, String.valueOf(i)));
+                producer.send(new ProducerRecord<>("t2", "t2-" + i, String.valueOf(i)));
             }
             LOGGER.info("Published " + MESSAGE_COUNT_PER_TOPIC + " messages to topic t1");
             LOGGER.info("Published " + MESSAGE_COUNT_PER_TOPIC + " messages to topic t2");


### PR DESCRIPTION
Related to https://github.com/hazelcast/hazelcast-code-samples/pull/529
Related to https://hazelcast.atlassian.net/browse/HZ-949

Use String values in Kafka samples to make them readable in Confluent Control Center UI

Before:
<img width="960" alt="image001" src="https://user-images.githubusercontent.com/1242724/165446686-60c662d2-f998-42f3-8464-7e4d45e51d89.png">

After:
![image](https://user-images.githubusercontent.com/1242724/165448370-7dfcec54-38f4-468c-8da6-c98e7cf88923.png)

