### PR TITLE
Set version of spring-boot-maven-plugin in plugin management

### DIFF
--- a/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
+++ b/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
@@ -79,6 +79,15 @@
 	</dependencyManagement>
 
 	<build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
 		<!-- Define docker plugin for all modules to use, skip per module when not needed -->
 		<plugins>
 			<plugin>

--- a/hazelcast-integration/spring-data-hazelcast-chemistry-sample/pom.xml
+++ b/hazelcast-integration/spring-data-hazelcast-chemistry-sample/pom.xml
@@ -88,4 +88,16 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/sql/hazdb/pom.xml
+++ b/sql/hazdb/pom.xml
@@ -129,6 +129,11 @@
 						</filesets>
 					</configuration>
 				</plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring-boot.version}</version>
+                </plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Some code samples which use `spring-boot-maven-plugin` currently fail with:
```
[ERROR] Failed to execute goal org.springframework.boot:spring-boot-maven-plugin:3.0.0:repackage (default) on project the-client: Execution default of goal org.springframework.boot:spring-boot-maven-plugin:3.0.0:repackage failed: Unable to load the mojo 'repackage' in the plugin 'org.springframework.boot:spring-boot-maven-plugin:3.0.0' due to an API incompatibility: org.codehaus.plexus.component.repository.exception.ComponentLookupException: org/springframework/boot/maven/RepackageMojo has been compiled by a more recent version of the Java Runtime (class file version 61.0), this version of the Java Runtime only recognizes class file versions up to 52.0
```