### PR TITLE
Remove redundant destroy call for the same distributed object

### DIFF
--- a/cp-subsystem/fenced-lock-monotonic-fencing-tokens/src/main/java/com/hazelcast/codesamples/cp/fencedlock/MonotonicFencingTokens.java
+++ b/cp-subsystem/fenced-lock-monotonic-fencing-tokens/src/main/java/com/hazelcast/codesamples/cp/fencedlock/MonotonicFencingTokens.java
@@ -53,7 +53,6 @@ public class MonotonicFencingTokens {
 
         // always destroy CP Subsystem data structures otherwise it can lead to a memory leak
         hz1Lock.destroy();
-        hz2Lock.destroy();
 
         hz1.getLifecycleService().terminate();
         hz2.getLifecycleService().terminate();

--- a/cp-subsystem/fenced-lock-using-fencing-tokens/src/main/java/com/hazelcast/codesamples/cp/fencedlock/FencingOffStaleLockHolders.java
+++ b/cp-subsystem/fenced-lock-using-fencing-tokens/src/main/java/com/hazelcast/codesamples/cp/fencedlock/FencingOffStaleLockHolders.java
@@ -132,7 +132,6 @@ public class FencingOffStaleLockHolders {
 
         // always destroy CP Subsystem data structures otherwise it can lead to a memory leak
         hz1Lock.destroy();
-        hz2Lock.destroy();
 
         hz1.getLifecycleService().terminate();
         hz2.getLifecycleService().terminate();


### PR DESCRIPTION
Remove redundant destroy for the same object.
There is no need to call destroy() several times if they are applied to the same distributed object.
