### PR TITLE
Resolve mongo `throwOnNonExisting` compilation error

### DIFF
--- a/jet/mongodb/src/main/java/com/hazelcast/samples/jet/mongodb/MongoSourceExample.java
+++ b/jet/mongodb/src/main/java/com/hazelcast/samples/jet/mongodb/MongoSourceExample.java
@@ -21,6 +21,7 @@ import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.jet.JetService;
 import com.hazelcast.jet.Job;
 import com.hazelcast.jet.mongodb.MongoSources;
+import com.hazelcast.jet.mongodb.ResourceChecks;
 import com.hazelcast.jet.pipeline.Pipeline;
 import com.hazelcast.jet.pipeline.Sinks;
 import com.hazelcast.jet.pipeline.StreamSource;
@@ -100,7 +101,7 @@ public class MongoSourceExample {
                 .database("shop")
                 .filter(eq("fullDocument.successful", true))
                 .collection("payments", Payment.class)
-                .throwOnNonExisting(false)
+                .checkResourceExistence(ResourceChecks.NEVER)
                 .startAtOperationTime(new BsonTimestamp())
                 .build();
         pipeline.readFrom(streamSource)


### PR DESCRIPTION
Replaced `throwOnNonExisting` with `checkResourceExistence` as per example in [https://github.com/hazelcast/hazelcast/commit/4fb06583ed3135be442b95e5d4320cf7cb074914 extensions/mongodb/src/test/java/com/hazelcast/jet/mongodb/MongoSinkTest.java`](https://github.com/hazelcast/hazelcast/commit/4fb06583ed3135be442b95e5d4320cf7cb074914#diff-e80451e6aa925a62c2ae1f81598c68283d795dd1bb10a1b1000b45fcf2c34959)

Fixes https://github.com/hazelcast/hazelcast-code-samples/issues/590