### PR TITLE
Update 5.3.z SNAPSHOT version to 5.3.6 [5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <jdk.version>1.8</jdk.version>
         <jdk.integration.version>1.8</jdk.integration.version>
 
-        <hazelcast.version>5.3.4-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.3.6-SNAPSHOT</hazelcast.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
         <hazelcast.hibernate.version>2.3.0</hazelcast.hibernate.version>
 


### PR DESCRIPTION
We have skipped 5.3.3 and 5.3.4 and released 5.3.5 instead. This change will ensure next release (5.3.6) is properly created from 5.3.z

Fixes: [HZ-3546]

[HZ-3546]: https://hazelcast.atlassian.net/browse/HZ-3546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ