### PR TITLE
Revert "Update Predicate initialization syntax following UCD/`namespace` changes"

### DIFF
--- a/distributed-map/paging-predicate/src/main/java/PagingPredicateQuery.java
+++ b/distributed-map/paging-predicate/src/main/java/PagingPredicateQuery.java
@@ -49,8 +49,7 @@ public class PagingPredicateQuery {
         Comparator<Map.Entry<Integer, Student>> descendingComparator = new DescendingIdComparator();
 
         // a predicate which filters out non ClassA students, sort them descending order and fetches 4 students for each page
-        PagingPredicate<Integer, Student> pagingPredicate =
-                Predicates.pagingPredicate(equalPredicate, descendingComparator, 4, null);
+        PagingPredicate pagingPredicate = Predicates.pagingPredicate(equalPredicate, descendingComparator, 4);
 
         // expected result:
         // Page 1 -> Student-18, Student-16, Student-14, Student-12


### PR DESCRIPTION
Reverts hazelcast/hazelcast-code-samples#603

Will be addressing this issue via https://github.com/hazelcast/hazelcast-mono/pull/237 instead