### PR TITLE
Remove conflicting Java version specification [HZ-4160]

### DIFF
--- a/enterprise/wan-replication/simulating-max-idle/pom.xml
+++ b/enterprise/wan-replication/simulating-max-idle/pom.xml
@@ -14,8 +14,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/hazelcast-integration/jca-ra/pom.xml
+++ b/hazelcast-integration/jca-ra/pom.xml
@@ -23,8 +23,6 @@
         <version.jboss.maven.plugin>7.1.1.Final</version.jboss.maven.plugin>
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>
         <version.war.plugin>3.3.2</version.war.plugin>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
     </properties>
 
     <dependencyManagement>

--- a/hazelcast-integration/openshift/client-apps/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/pom.xml
@@ -24,9 +24,6 @@
 
         <spring.version>4.3.7.RELEASE</spring.version>
         <spring.boot.version>1.5.2.RELEASE</spring.boot.version>
-
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 
     <modules>

--- a/hazelcast-integration/pom.xml
+++ b/hazelcast-integration/pom.xml
@@ -77,19 +77,4 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>${maven.compiler.plugin.version}</version>
-                <configuration>
-                    <source>${jdk.integration.version}</source>
-                    <target>${jdk.integration.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/jcache-1.1/times-table/pom.xml
+++ b/jcache-1.1/times-table/pom.xml
@@ -106,15 +106,6 @@
 
     <build>
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                    <encoding>${project.build.sourceEncoding}</encoding>
-                </configuration>
-            </plugin>
             <!-- Reduces "Artifact has not been packaged yet" issue -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -19,9 +19,6 @@
         <main.basedir>${project.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-
         <jsr107.api.version>1.1.1</jsr107.api.version>
     </properties>
 

--- a/jet/cdc/pom.xml
+++ b/jet/cdc/pom.xml
@@ -63,16 +63,4 @@
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
-                <configuration>
-                    <release>17</release>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/jet/hazelcast-3-connector/hazelcast-3-member/pom.xml
+++ b/jet/hazelcast-3-connector/hazelcast-3-member/pom.xml
@@ -38,5 +38,7 @@
         <!-- needed for checkstyle/findbugs -->
         <!--<main.basedir>${project.parent.parent.basedir}</main.basedir>-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 </project>

--- a/jet/hazelcast-3-connector/hazelcast-3-member/pom.xml
+++ b/jet/hazelcast-3-connector/hazelcast-3-member/pom.xml
@@ -38,7 +38,5 @@
         <!-- needed for checkstyle/findbugs -->
         <!--<main.basedir>${project.parent.parent.basedir}</main.basedir>-->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
 </project>

--- a/jet/mongodb/pom.xml
+++ b/jet/mongodb/pom.xml
@@ -41,19 +41,6 @@
         <log4j2.version>2.20.0</log4j2.version>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
-                <configuration>
-                    <release>17</release>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <dependency>
             <groupId>com.hazelcast.jet</groupId>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -46,19 +46,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven.compiler.plugin.version}</version>
-				<configuration>
-					<source>${jdk.integration.version}</source>
-					<target>${jdk.integration.version}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/near-cache/pom.xml
+++ b/near-cache/pom.xml
@@ -46,19 +46,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven.compiler.plugin.version}</version>
-				<configuration>
-					<source>${jdk.integration.version}</source>
-					<target>${jdk.integration.version}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/org-website-samples/pom.xml
+++ b/org-website-samples/pom.xml
@@ -12,18 +12,6 @@
 
     <name>org-website-samples</name>
     <url>http://maven.apache.org</url>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 
     <properties>
         <!-- needed for checkstyle/findbugs -->

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -18,8 +18,6 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.target>1.6</maven.compiler.target>
-        <maven.compiler.source>1.6</maven.compiler.source>
 
         <osgi.version>6.0.0</osgi.version>
         <felix.version>5.4.0</felix.version>

--- a/querying/pom.xml
+++ b/querying/pom.xml
@@ -46,19 +46,4 @@
 			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven.compiler.plugin.version}</version>
-				<configuration>
-					<source>${jdk.integration.version}</source>
-					<target>${jdk.integration.version}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/serialization/benchmarks/pom.xml
+++ b/serialization/benchmarks/pom.xml
@@ -101,17 +101,4 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>${maven-compiler-plugin.version}</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/serialization/hazelcast-airlines/pom.xml
+++ b/serialization/hazelcast-airlines/pom.xml
@@ -71,19 +71,4 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
-
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-					<encoding>${project.build.sourceEncoding}</encoding>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
-
 </project>

--- a/spi/tenant-control/pom.xml
+++ b/spi/tenant-control/pom.xml
@@ -26,18 +26,6 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-
     <profiles>
         <profile>
             <id>member</id>


### PR DESCRIPTION
Although `maven-compiler-plugin` is configured with `<release>17</release>` in the parent POM, some child POMs are setting conflicting values:

- E.G. `<maven.compiler.source>1.8</maven.compiler.source>` property
- Redeclaring `maven-compiler-plugin` with their own `configuration` for `source`/`target`

Fixes [HZ-4160](https://hazelcast.atlassian.net/browse/HZ-4160)

[HZ-4160]: https://hazelcast.atlassian.net/browse/HZ-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ