### PR TITLE
Prepare 5.2.5 release branch from v5.2.4 [HZ-3723][5.2.5]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <jdk.version>1.8</jdk.version>
         <jdk.integration.version>1.8</jdk.integration.version>
 
-        <hazelcast.version>5.2.4</hazelcast.version>
+        <hazelcast.version>5.2.5-SNAPSHOT</hazelcast.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
 
         <!-- Used in ClientConsole application-->


### PR DESCRIPTION
1. Changes to prepare for 5.2.5 release
2. Branch was manually created from v5.2.4
3. Updated POM version manually to 5.2.5-SNAPSHOT
Fixes: [HZ-3723]

[HZ-3723]: https://hazelcast.atlassian.net/browse/HZ-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ