### PR TITLE
Update POM version to 5.2.6-SNAPSHOT [HZ-3723]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <jdk.version>1.8</jdk.version>
         <jdk.integration.version>1.8</jdk.integration.version>
 
-        <hazelcast.version>5.2.5-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.2.6-SNAPSHOT</hazelcast.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
 
         <!-- Used in ClientConsole application-->


### PR DESCRIPTION
Update version in 5.2.z to 5.2.6-SNAPSHOT

Follow-up from https://github.com/hazelcast/hazelcast-code-samples/pull/615

Fixes: [HZ-3723]

[HZ-3723]: https://hazelcast.atlassian.net/browse/HZ-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ