### PR TITLE
Fix `code-samples` post `hazelcast` Protobuf upgrade

### DIFF
--- a/jet/grpc/pom.xml
+++ b/jet/grpc/pom.xml
@@ -41,6 +41,11 @@
             <version>1.3.2</version>
             <scope>provided</scope>
         </dependency>
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>${protobuf.version}</version>
+		</dependency>
     </dependencies>
 
     <build>
@@ -74,7 +79,7 @@
     </build>
 
     <properties>
-        <!-- needed for checkstyle/findbugs -->
+		<!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/jet/grpc/pom.xml
+++ b/jet/grpc/pom.xml
@@ -41,11 +41,11 @@
             <version>1.3.2</version>
             <scope>provided</scope>
         </dependency>
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-			<version>${protobuf.version}</version>
-		</dependency>
+	<dependency>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+            <version>${protobuf.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -79,7 +79,7 @@
     </build>
 
     <properties>
-		<!-- needed for checkstyle/findbugs -->
+	<!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <zookeeper.version>3.5.8</zookeeper.version>
         <kafka.version>2.8.1</kafka.version>
         <grpc.version>1.47.0</grpc.version>
-        <protobuf.version>3.21.2</protobuf.version>
+        <protobuf.version>4.26.0</protobuf.version>
         <maven.os.plugin.version>1.6.2</maven.os.plugin.version>
         <maven.protobuf.plugin.version>0.6.1</maven.protobuf.plugin.version>
         <maven.surefire.plugin.version>3.0.0</maven.surefire.plugin.version>

--- a/serialization/benchmarks/pom.xml
+++ b/serialization/benchmarks/pom.xml
@@ -34,7 +34,6 @@
 		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<os-maven-plugin.version>1.7.0</os-maven-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<protobuf.version>3.21.7</protobuf.version>
 		<protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
 		<slf4j.version>1.7.30</slf4j.version>
 	</properties>


### PR DESCRIPTION
[`hazelcast`'s protobuf dependency version was upgraded](https://github.com/hazelcast/hazelcast-mono/pull/1102), which due to [breaking changes](https://github.com/protocolbuffers/protobuf/releases/tag/v26.0) caused conflict with the version specified in `code-samples`.

Fixed by upgrading version in `code-samples`, too.

Fixes: https://github.com/hazelcast/hazelcast-code-samples/issues/621