### PR TITLE
Update POM version to 5.3.8-SNAPSHOT [HZ-4188][5.3.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <jdk.version>1.8</jdk.version>
         <jdk.integration.version>1.8</jdk.integration.version>
 
-        <hazelcast.version>5.3.7-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.3.8-SNAPSHOT</hazelcast.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
         <hazelcast.hibernate.version>2.3.0</hazelcast.hibernate.version>
 


### PR DESCRIPTION
Updating 5.3.z branch after Release 5.3.7 branch was created previously from v5.3.6

Fixes: [HZ-4188]

Backport of: https://github.com/hazelcast/hazelcast-code-samples/pull/624

[HZ-4188]: https://hazelcast.atlassian.net/browse/HZ-4188?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ