### PR TITLE
Update XSDs to version `5.5`

### DIFF
--- a/clients/client-labels/src/main/resources/hazelcast-client.xml
+++ b/clients/client-labels/src/main/resources/hazelcast-client.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <instance-name>Client2</instance-name>

--- a/clients/client-near-cache/src/main/resources/hazelcast-client.xml
+++ b/clients/client-near-cache/src/main/resources/hazelcast-client.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <near-cache name="articlesSerializedKeys">

--- a/clients/client-statistics/src/main/resources/hazelcast-client.xml
+++ b/clients/client-statistics/src/main/resources/hazelcast-client.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
     <properties>
         <property name="hazelcast.client.statistics.enabled">true</property>

--- a/cluster-split-brain-protection-xml/src/main/resources/hazelcast.xml
+++ b/cluster-split-brain-protection-xml/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <!--

--- a/distributed-collections/boundedblockingqueue/src/main/resources/hazelcast.xml
+++ b/distributed-collections/boundedblockingqueue/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-collections/queuestore/src/main/resources/hazelcast.xml
+++ b/distributed-collections/queuestore/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <!-- we need to configure the queue store here -->

--- a/distributed-collections/ringbuffer/src/main/resources/hazelcast.xml
+++ b/distributed-collections/ringbuffer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-collections/ringbufferstore/src/main/resources/hazelcast.xml
+++ b/distributed-collections/ringbufferstore/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <ringbuffer name="object-ringbuffer-xml">

--- a/distributed-executor/scale-out/src/main/resources/hazelcast.xml
+++ b/distributed-executor/scale-out/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-executor/scale-up/src/main/resources/hazelcast.xml
+++ b/distributed-executor/scale-up/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <executor-service name="executor">

--- a/distributed-map/backup/src/main/resources/hazelcast.xml
+++ b/distributed-map/backup/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/distributed-map/custom-attributes/src/main/resources/hazelcast.xml
+++ b/distributed-map/custom-attributes/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/distributed-map/entry-processor/src/main/resources/hazelcast.xml
+++ b/distributed-map/entry-processor/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/distributed-map/eviction/src/main/resources/hazelcast.xml
+++ b/distributed-map/eviction/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/distributed-map/fast-aggregations/src/main/resources/hazelcast.xml
+++ b/distributed-map/fast-aggregations/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-map/hashcode-and-equals/src/main/resources/hazelcast.xml
+++ b/distributed-map/hashcode-and-equals/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <map name="objectMap">

--- a/distributed-map/in-memory-format/src/main/resources/hazelcast.xml
+++ b/distributed-map/in-memory-format/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-map/index/src/main/resources/hazelcast.xml
+++ b/distributed-map/index/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/distributed-map/nearcache/src/main/resources/hazelcast.xml
+++ b/distributed-map/nearcache/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <map name="articlesSerializedKeys">

--- a/distributed-map/projections/src/main/resources/hazelcast.xml
+++ b/distributed-map/projections/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/distributed-topic/reliable-topic/src/main/resources/hazelcast.xml
+++ b/distributed-topic/reliable-topic/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/enterprise/client-custom-credentials/src/main/resources/hazelcast-client.xml
+++ b/enterprise/client-custom-credentials/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
     <security>
         <credentials-factory class-name="com.hazelcast.examples.CustomCredentialsFactory">

--- a/enterprise/client-custom-credentials/src/main/resources/hazelcast.xml
+++ b/enterprise/client-custom-credentials/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <license-key>PUT_YOUR_HAZELCAST_LICENSE_HERE</license-key>

--- a/enterprise/client-failover-cluster/src/main/resources/clientToCluster1.xml
+++ b/enterprise/client-failover-cluster/src/main/resources/clientToCluster1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cluster1</cluster-name>

--- a/enterprise/client-failover-cluster/src/main/resources/clientToCluster2.xml
+++ b/enterprise/client-failover-cluster/src/main/resources/clientToCluster2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cluster1</cluster-name>

--- a/enterprise/client-failover-cluster/src/main/resources/hazelcast-client-failover.xml
+++ b/enterprise/client-failover-cluster/src/main/resources/hazelcast-client-failover.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client-failover xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                            xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-5.5.xsd"
                            xmlns="http://www.hazelcast.com/schema/client-config">
     <try-count>5</try-count>
     <clients>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cache</cluster-name>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/resources/hazelcast-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/src/main/resources/hazelcast-hd-memory.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>cache</cluster-name>

--- a/enterprise/ldap-authentication/basic-config-direct-search/hazelcast-client-unauthorized.xml
+++ b/enterprise/ldap-authentication/basic-config-direct-search/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="uid=jduke,ou=Users,dc=hazelcast,dc=com" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/basic-config-direct-search/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/basic-config-direct-search/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="uid=hazelcast,ou=Users,dc=hazelcast,dc=com" password="imdg"/>
   </security>

--- a/enterprise/ldap-authentication/basic-config-direct-search/hazelcast.xml
+++ b/enterprise/ldap-authentication/basic-config-direct-search/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/basic-config-reverse-role/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/basic-config-reverse-role/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="uid=jduke,ou=Users,dc=hazelcast,dc=com" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/basic-config-reverse-role/hazelcast.xml
+++ b/enterprise/ldap-authentication/basic-config-reverse-role/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/basic-config-simple/hazelcast-client-unauthorized.xml
+++ b/enterprise/ldap-authentication/basic-config-simple/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="uid=jduke,ou=Users,dc=hazelcast,dc=com" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/basic-config-simple/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/basic-config-simple/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="uid=hazelcast,ou=Users,dc=hazelcast,dc=com" password="imdg"/>
   </security>

--- a/enterprise/ldap-authentication/basic-config-simple/hazelcast.xml
+++ b/enterprise/ldap-authentication/basic-config-simple/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast-client-unauthorized.xml
+++ b/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="Java Duke" password="duke"/>
   </security>

--- a/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="Best IMDG" password="Hazelcast"/>
   </security>

--- a/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast.xml
+++ b/enterprise/ldap-authentication/config-custom-password-attribute/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/config-direct-search/hazelcast-client-unauthorized.xml
+++ b/enterprise/ldap-authentication/config-direct-search/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="jduke" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/config-direct-search/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/config-direct-search/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="hazelcast" password="imdg"/>
   </security>

--- a/enterprise/ldap-authentication/config-direct-search/hazelcast.xml
+++ b/enterprise/ldap-authentication/config-direct-search/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/config-reverse-role/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/config-reverse-role/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="jduke" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/config-reverse-role/hazelcast.xml
+++ b/enterprise/ldap-authentication/config-reverse-role/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/ldap-authentication/config-simple/hazelcast-client-unauthorized.xml
+++ b/enterprise/ldap-authentication/config-simple/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="jduke" password="theduke"/>
   </security>

--- a/enterprise/ldap-authentication/config-simple/hazelcast-client.xml
+++ b/enterprise/ldap-authentication/config-simple/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.2.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
   <security>
     <username-password username="hazelcast" password="imdg"/>
   </security>

--- a/enterprise/ldap-authentication/config-simple/hazelcast.xml
+++ b/enterprise/ldap-authentication/config-simple/hazelcast.xml
@@ -1,4 +1,4 @@
-<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-4.2.xsd">
+<hazelcast xmlns="http://www.hazelcast.com/schema/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <security enabled="true">
           <realms>

--- a/enterprise/simple-authentication/hazelcast-client-unauthorized.xml
+++ b/enterprise/simple-authentication/hazelcast-client-unauthorized.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
     <security>
         <username-password username="test" password="a1234" />
     </security>

--- a/enterprise/simple-authentication/hazelcast-client.xml
+++ b/enterprise/simple-authentication/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.0.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
     <security>
         <username-password username="root" password="secret" />
     </security>

--- a/enterprise/simple-authentication/hazelcast.xml
+++ b/enterprise/simple-authentication/hazelcast.xml
@@ -1,6 +1,6 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.0.xsd">
+    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <security enabled="true">
         <realms>

--- a/enterprise/ssl/src/main/resources/hazelcast.xml
+++ b/enterprise/ssl/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <license-key>YOUR_LICENSE_KEY</license-key>

--- a/enterprise/symmetric-encryption/src/main/resources/hazelcast.xml
+++ b/enterprise/symmetric-encryption/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <license-key>YOUR_LICENSE_KEY</license-key>

--- a/enterprise/tls-custom-login-module/README.md
+++ b/enterprise/tls-custom-login-module/README.md
@@ -28,7 +28,7 @@ In addition, the Subject name attribute can be used as a role-provider.
 ```xml
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.2.xsd">
+    xsi:schemaLocation="http://www.hazelcast.com/schema/config http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
      <license-key>YOUR_LICENSE_KEY</license-key>
      <network>
@@ -91,7 +91,7 @@ In addition, the Subject name attribute can be used as a role-provider.
 <hazelcast-client
     xmlns="http://www.hazelcast.com/schema/client-config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.hazelcast.com/schema/client-config http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.2.xsd">
+    xsi:schemaLocation="http://www.hazelcast.com/schema/client-config http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
 
   <network>
     <ssl enabled="true">

--- a/enterprise/tls-rbac-demo/resources/admin-hazelcast-client.xml
+++ b/enterprise/tls-rbac-demo/resources/admin-hazelcast-client.xml
@@ -2,7 +2,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.1.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
 
     <network>
         <ssl enabled="true">

--- a/enterprise/tls-rbac-demo/resources/hazelcast.xml
+++ b/enterprise/tls-rbac-demo/resources/hazelcast.xml
@@ -3,7 +3,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.1.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <license-key>The key will be configured programmatically by LicenseUtils.</license-key>
 

--- a/enterprise/tls-rbac-demo/resources/regular-hazelcast-client.xml
+++ b/enterprise/tls-rbac-demo/resources/regular-hazelcast-client.xml
@@ -3,7 +3,7 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.1.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
 
     <network>
         <ssl enabled="true">

--- a/enterprise/wan-replication/basic-sample/src/main/resources/hazelcast-wan-source.xml
+++ b/enterprise/wan-replication/basic-sample/src/main/resources/hazelcast-wan-source.xml
@@ -22,7 +22,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <!--
       The name of the source cluster. It doesn't matter for WAN replication.

--- a/enterprise/wan-replication/basic-sample/src/main/resources/hazelcast-wan-target.xml
+++ b/enterprise/wan-replication/basic-sample/src/main/resources/hazelcast-wan-target.xml
@@ -22,7 +22,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <!--
       The name of the target cluster. This needs to be set in the `wan-publisher`

--- a/enterprise/wan-replication/interactive-sample/src/main/resources/hazelcast.xml
+++ b/enterprise/wan-replication/interactive-sample/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>clusterA</cluster-name>

--- a/hazelcast-integration/dynacache/hz-client.xml
+++ b/hazelcast-integration/dynacache/hz-client.xml
@@ -17,7 +17,7 @@
 
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                                      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.11.xsd"
+                                      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <properties>
         <property name="hazelcast.client.shuffle.member.list">true</property>

--- a/hazelcast-integration/filter-based-session-replication/src/main/webapp/WEB-INF/hazelcast.xml
+++ b/hazelcast-integration/filter-based-session-replication/src/main/webapp/WEB-INF/hazelcast.xml
@@ -1,6 +1,6 @@
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-3.11.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <management-center enabled="true">http://localhost:8090/mancenter</management-center>

--- a/hazelcast-integration/hibernate-2ndlevel-cache/src/main/resources/hazelcast-client.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/src/main/resources/hazelcast-client.xml
@@ -17,5 +17,5 @@
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.3.xsd">
+                  http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd">
 </hazelcast-client>

--- a/hazelcast-integration/hibernate-2ndlevel-cache/src/main/resources/hazelcast.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/src/main/resources/hazelcast.xml
@@ -17,7 +17,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <!-- Hibernate regions can be configured here using the map names. -->
     <map name="custom_region_name">

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/main/resources/hazelcast.xml
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/main/resources/hazelcast.xml
@@ -2,7 +2,7 @@
 <hazelcast xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-           http://www.hazelcast.com/schema/config/hazelcast-config-5.3.xsd">
+           http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd">
 
     <cluster-name>dev</cluster-name>
 

--- a/hazelcast-integration/springaware-annotation/src/main/resources/applicationContext.xml
+++ b/hazelcast-integration/springaware-annotation/src/main/resources/applicationContext.xml
@@ -7,7 +7,7 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans
 		http://www.springframework.org/schema/beans/spring-beans-2.5.xsd
 		http://www.hazelcast.com/schema/spring
-		http://www.hazelcast.com/schema/spring/hazelcast-spring-4.0.xsd
+		http://www.hazelcast.com/schema/spring/hazelcast-spring-5.5.xsd
 		http://www.springframework.org/schema/context
         http://www.springframework.org/schema/context/spring-context.xsd">
 

--- a/jcache-1.1/times-table/jcache-server/src/main/resources/hazelcast.xml
+++ b/jcache-1.1/times-table/jcache-server/src/main/resources/hazelcast.xml
@@ -1,6 +1,6 @@
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-3.12.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/jcache-1.1/times-table/jcache-spring/src/main/resources/hazelcast-client.xml
+++ b/jcache-1.1/times-table/jcache-spring/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.12.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <network>

--- a/jcache-1.1/times-table/jcache-standard/src/main/resources/hazelcast-client.xml
+++ b/jcache-1.1/times-table/jcache-standard/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-3.12.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <network>

--- a/jcache/src/main/resources/hazelcast-client-c1.xml
+++ b/jcache/src/main/resources/hazelcast-client-c1.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cluster1</cluster-name>

--- a/jcache/src/main/resources/hazelcast-client-c2.xml
+++ b/jcache/src/main/resources/hazelcast-client-c2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cluster2</cluster-name>

--- a/jcache/src/main/resources/hazelcast-client.xml
+++ b/jcache/src/main/resources/hazelcast-client.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cluster1</cluster-name>

--- a/jcache/src/main/resources/hazelcast-declarative-eviction-test.xml
+++ b/jcache/src/main/resources/hazelcast-declarative-eviction-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cache name="cache">

--- a/jcache/src/main/resources/hazelcast-declarative-full.xml
+++ b/jcache/src/main/resources/hazelcast-declarative-full.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cache name="cache">

--- a/jcache/src/main/resources/hazelcast-declarative-listener-test.xml
+++ b/jcache/src/main/resources/hazelcast-declarative-listener-test.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cache name="cache">

--- a/jcache/src/main/resources/hazelcast-split-brain-protection.xml
+++ b/jcache/src/main/resources/hazelcast-split-brain-protection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>dev</cluster-name>

--- a/jcache/src/main/resources/hazelcast-splitbrain.xml
+++ b/jcache/src/main/resources/hazelcast-splitbrain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>dev</cluster-name>

--- a/jcache/src/main/resources/hazelcast.xml
+++ b/jcache/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/learning-basics/configure-logging/src/main/resources/hazelcast.xml
+++ b/learning-basics/configure-logging/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-client-network-config.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-client-network-config.xml
@@ -17,7 +17,7 @@
 
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <network>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-client.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <import resource="hazelcast-client-network-config.xml"/>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast-network-config.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast-network-config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/learning-basics/configure-xml/src/main/resources/hazelcast.xml
+++ b/learning-basics/configure-xml/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <import resource="hazelcast-network-config.xml"/>

--- a/learning-basics/configure-yaml/src/main/resources/hazelcast.xml
+++ b/learning-basics/configure-yaml/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <port>6000</port>

--- a/learning-basics/destroying-instances/src/main/resources/hazelcast.xml
+++ b/learning-basics/destroying-instances/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/learning-basics/loading-instances/src/main/resources/hazelcast.xml
+++ b/learning-basics/loading-instances/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <queue name="q"/>

--- a/learning-basics/wildcard-configuration/src/main/resources/hazelcast.xml
+++ b/learning-basics/wildcard-configuration/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <map name="testmap*">

--- a/near-cache/fraud-detection/fraud-detection-client-with/src/main/resources/hazelcast-client.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-with/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <!-- This is the configuration for a client with a Near Cache.

--- a/near-cache/fraud-detection/fraud-detection-client-without/src/main/resources/hazelcast-client.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-without/src/main/resources/hazelcast-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <!-- This is the configuration for a client without a Near Cache.

--- a/near-cache/fraud-detection/fraud-detection-server/src/main/resources/hazelcast.xml
+++ b/near-cache/fraud-detection/fraud-detection-server/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/aws/src/main/resources/hazelcast.xml
+++ b/network-configuration/aws/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/firewall/src/main/resources/hazelcast.xml
+++ b/network-configuration/firewall/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/groups/group1/src/main/resources/hazelcast.xml
+++ b/network-configuration/groups/group1/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>group1</cluster-name>

--- a/network-configuration/groups/group2/src/main/resources/hazelcast.xml
+++ b/network-configuration/groups/group2/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>group2</cluster-name>

--- a/network-configuration/multicast-plugin/src/main/resources/hazelcast.xml
+++ b/network-configuration/multicast-plugin/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <properties>

--- a/network-configuration/multicast/src/main/resources/hazelcast.xml
+++ b/network-configuration/multicast/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/partitiongroup/src/main/resources/hazelcast.xml
+++ b/network-configuration/partitiongroup/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/port/src/main/resources/hazelcast.xml
+++ b/network-configuration/port/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/network-configuration/tcpip/src/main/resources/hazelcast.xml
+++ b/network-configuration/tcpip/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <network>

--- a/replicated-map/in-memory-format/src/main/resources/hazelcast.xml
+++ b/replicated-map/in-memory-format/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
     <network>
         <join>

--- a/serialization/bytearray-serializer/src/main/resources/hazelcast.xml
+++ b/serialization/bytearray-serializer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/global-serializer/src/main/resources/hazelcast.xml
+++ b/serialization/global-serializer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/identified-data-serializable/src/main/resources/hazelcast.xml
+++ b/serialization/identified-data-serializable/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/kryo-serializer/src/main/resources/hazelcast.xml
+++ b/serialization/kryo-serializer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/portable/src/main/resources/hazelcast.xml
+++ b/serialization/portable/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/protobuf-serializer/src/main/resources/hazelcast.xml
+++ b/serialization/protobuf-serializer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/serialization/stream-serializer/src/main/resources/hazelcast.xml
+++ b/serialization/stream-serializer/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <serialization>

--- a/spi/discovery/src/main/resources/hazelcast.xml
+++ b/spi/discovery/src/main/resources/hazelcast.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <!-- activate Discovery SPI -->

--- a/variable-replacers/hazelcast-exec-linux.xml
+++ b/variable-replacers/hazelcast-exec-linux.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <config-replacers>

--- a/variable-replacers/hazelcast-exec-windows.xml
+++ b/variable-replacers/hazelcast-exec-windows.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <config-replacers>

--- a/variable-replacers/hazelcast-plain.xml
+++ b/variable-replacers/hazelcast-plain.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <cluster-name>Variable Test Group</cluster-name>

--- a/variable-replacers/hazelcast-with-replacers.xml
+++ b/variable-replacers/hazelcast-with-replacers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <hazelcast xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://www.hazelcast.com/schema/config
-                               http://www.hazelcast.com/schema/config/hazelcast-config-4.0.xsd"
+                               http://www.hazelcast.com/schema/config/hazelcast-config-5.5.xsd"
            xmlns="http://www.hazelcast.com/schema/config">
 
     <config-replacers>


### PR DESCRIPTION
Addresses the symptom (not root cause) of https://github.com/hazelcast/hazelcast/issues/26315

Increments:
- `http://www.hazelcast.com/schema/config/hazelcast-config-x.y.xsd`
- `http://www.hazelcast.com/schema/spring/hazelcast-spring-x.y.xsd`
- `http://www.hazelcast.com/schema/client-config/hazelcast-client-config-x.y.xsd`
- `http://www.hazelcast.com/schema/client-config/hazelcast-client-failover-config-x.y.xsd`

For all modules which are using the default `hazelcast.version` version of Hazelcast (i.e. `5.5.0-SNAPSHOT`), which is everything _except_:
- `hazelcast-integration/eureka/springboot-embedded`
- `hazelcast-integration/aws-ecs`
- `hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world`
- `hazelcast-integration/spring-data-hazelcast-chemistry-sample`
- `hazelcast-integration/spring-data-jpa-hazelcast-migration`
- `jcache-1.1/times-table`
- `network-configuration/jcloud`
- `network-configuration/jclouds-partitiongroup`
- `querying/project-key`
- `serialization/hazelcast-airlines`
- `sql/hazdb`

[`hazelcast-mono` corresponding PR](https://github.com/hazelcast/hazelcast-mono/pull/1370)