### PR TITLE
Make default Hazelcast version, last released version (i.e. not `SNAPSHOT`).

### DIFF
--- a/jet/wordcount-compute-isolation/pom.xml
+++ b/jet/wordcount-compute-isolation/pom.xml
@@ -84,5 +84,7 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<!-- TODO Once Hazelcast v5.5 is released, can become non-SNAPSHOT -->
+		<hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
     </properties>
 </project>

--- a/jet/wordcount-compute-isolation/pom.xml
+++ b/jet/wordcount-compute-isolation/pom.xml
@@ -84,7 +84,7 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<!-- TODO Once Hazelcast v5.5 is released, can become non-SNAPSHOT -->
-		<hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
+        <!-- TODO Once Hazelcast v5.5 is released, can become non-SNAPSHOT -->
+        <hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.4.0</hazelcast.version>
         <java.version>17</java.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
         <hazelcast.hibernate.version>5.1.0</hazelcast.hibernate.version>


### PR DESCRIPTION
[`SNAPSHOT` Hazelcast builds are no longer publicly accessible](https://hazelcast.atlassian.net/browse/DI-100), which leads to build failures as `code-samples` [relies on `SNAPSHOT`s since virtually the beginning](https://github.com/hazelcast/hazelcast-code-samples/commit/c1121d4ac9169d56ed2879c337e9c345b1216322).

It makes more sense for examples of how to use Hazelcast to be backed by production-quality dependencies, i.e. a released version.

As such, downgraded to the latest released version of Hazelcast - will be kept up-to-date via [Dependabot](https://github.com/hazelcast/hazelcast-code-samples/pull/574).

[Slack discussion](https://hazelcast.slack.com/archives/C05LM8B80UT/p1716380405098929)