### PR TITLE
Use released Hazelcast `5.4.0` instead of `SNAPSHOT`

### DIFF
--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/README.md
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/README.md
@@ -43,7 +43,7 @@ In order to configure Hazelcast as second-level cache provider, you need to add 
 <dependency>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast</artifactId>
-    <version>5.4.0-SNAPSHOT</version>
+    <version>5.4.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Now `5.4.0` is released, the released version should be used in preferences to a pre-release `SNAPSHOT`.