### PR TITLE
Remove OS `SNAPSHOT` dependencies

### DIFF
--- a/jet/wordcount-compute-isolation/pom.xml
+++ b/jet/wordcount-compute-isolation/pom.xml
@@ -55,7 +55,8 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-enterprise</artifactId>
-            <version>${hazelcast.version}</version>
+            <!-- TODO Once Hazelcast v5.5 is released, can revert to ${hazelcast.version} -->
+            <version>5.5.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.hazelcast.samples</groupId>
@@ -84,7 +85,5 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- TODO Once Hazelcast v5.5 is released, can become non-SNAPSHOT -->
-        <hazelcast.version>5.5.0-SNAPSHOT</hazelcast.version>
     </properties>
 </project>


### PR DESCRIPTION
[`SNAPSHOT` Hazelcast builds are no longer publicly accessible](https://hazelcast.atlassian.net/browse/DI-100), which leads to build failures - `code-samples` uses OS `5.5.0-SNAPSHOT` which isn't accessible.

This artefact isn't required and instead be can be removed - only EE needs to be `5.5.0-SNAPSHOT`.

Follow on from https://github.com/hazelcast/hazelcast-code-samples/pull/636.

[Slack discussion](https://hazelcast.slack.com/archives/C07066ELRRD/p1719998723582069)