### PR TITLE
Fix HZ version  [5.4.z]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <hazelcast.version>5.4.1-SNAPSHOT</hazelcast.version>
+        <hazelcast.version>5.4.2-SNAPSHOT</hazelcast.version>
         <java.version>17</java.version>
         <hazelcast-jclouds.version>3.7.2</hazelcast-jclouds.version>
         <hazelcast.hibernate.version>5.1.0</hazelcast.hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,17 @@
                 <enabled>false</enabled>
             </releases>
         </repository>
+        <repository>
+            <id>private-repository</id>
+            <name>Jfrog Snapshot Internal</name>
+            <url>https://hazelcast.jfrog.io/artifactory/snapshot-internal</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
     </repositories>
 
     <modules>


### PR DESCRIPTION
We just branched 5.4.1 from 5.4.z and didn't actually create 5.4.1 branch in Code Samples as it is EE only release
This change will update <hazelcast.version> to `5.4.2-SNAPSHOT` ready for next release
This in similar vein as https://github.com/hazelcast/hazelcast-mono/blob/5.4.z/pom.xml

![image](https://github.com/hazelcast/hazelcast-code-samples/assets/12186256/53e3423c-c33f-4cc4-b067-f60ea2a9a478)

Planning to fix this as part of [DI-147](https://hazelcast.atlassian.net/browse/DI-147)

Fixes [REL-281](https://hazelcast.atlassian.net/browse/REL-281)

[DI-147]: https://hazelcast.atlassian.net/browse/DI-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[REL-281]: https://hazelcast.atlassian.net/browse/REL-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ