### PR TITLE
Resolve Maven missing version warnings

### DIFF
--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -36,7 +36,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>copy-resources</id>

--- a/hazelcast-integration/jca-ra/pom.xml
+++ b/hazelcast-integration/jca-ra/pom.xml
@@ -107,7 +107,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
-                <version>2.6</version>
                 <executions>
                     <execution>
                         <id>jboss-hazelcast-lib</id>

--- a/jet/trade-source/pom.xml
+++ b/jet/trade-source/pom.xml
@@ -33,6 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.2</version>
                 <configuration>
                     <skip>false</skip>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -149,6 +149,15 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven.surefire.plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.4.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/serialization/benchmarks/protobuf/pom.xml
+++ b/serialization/benchmarks/protobuf/pom.xml
@@ -67,6 +67,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.6.0</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>

--- a/sql/hazdb/client/pom.xml
+++ b/sql/hazdb/client/pom.xml
@@ -82,6 +82,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <!-- Find "package.json" and create "node_modules" -->
                     <workingDirectory>${frontend.app.dir}</workingDirectory>


### PR DESCRIPTION
During a build (`mvn clean | grep WARNING`), some warnings are logged:
```
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.jet:jet-hello-world:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 34, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.jet:jet-python:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 47, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.jet:jet-trade-source:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-deploy-plugin is missing. @ line 33, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.jet:jet-wordcount:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 34, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.jet:jet-wordcount-compute-isolation:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-jar-plugin is missing. @ line 69, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.serialization.benchmarks:serialization-benchmarks-protobuf:jar:1.0
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ line 67, column 21
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples.sql:hazdb-client:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for com.github.eirslett:frontend-maven-plugin is missing. @ line 82, column 21
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-resources-plugin is missing. @ line 122, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

Populated these versions (with latest, if missing) to address these warnings and improve build repeatability.