### PR TITLE
Update for `cluster-routing` change in 5.5

### DIFF
--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
@@ -16,7 +16,7 @@
   -->
 <hazelcast-client xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.4.xsd"
+                               http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns="http://www.hazelcast.com/schema/client-config">
 
     <cluster-name>cache</cluster-name>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/src/main/resources/hazelcast-client-hd-memory.xml
@@ -25,7 +25,7 @@
         <cluster-members>
             <address>127.0.0.1</address>
         </cluster-members>
-        <smart-routing>true</smart-routing>
+        <cluster-routing mode="ALL_MEMBERS"/>
         <redo-operation>true</redo-operation>
     </network>
 

--- a/hazelcast-integration/dynacache/hz-client.xml
+++ b/hazelcast-integration/dynacache/hz-client.xml
@@ -17,7 +17,7 @@
 
 <hazelcast-client xmlns="http://www.hazelcast.com/schema/client-config"
                   xsi:schemaLocation="http://www.hazelcast.com/schema/client-config
-                                      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.4.xsd"
+                                      http://www.hazelcast.com/schema/client-config/hazelcast-client-config-5.5.xsd"
                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <properties>
         <property name="hazelcast.client.shuffle.member.list">true</property>

--- a/hazelcast-integration/dynacache/hz-client.xml
+++ b/hazelcast-integration/dynacache/hz-client.xml
@@ -32,7 +32,7 @@
         <cluster-members>
             <address>127.0.0.1:5701</address>
         </cluster-members>
-        <smart-routing>true</smart-routing>
+        <cluster-routing mode="ALL_MEMBERS"/>
         <redo-operation>true</redo-operation>
         <connection-timeout>60000</connection-timeout>
         <connection-attempt-period>3000</connection-attempt-period>


### PR DESCRIPTION
`smart-routing` has been deprecated in favour of the new `cluster-routing` configuration section. See platform documentation for more information.

**This should not be merged until 5.5 is released!**