### PR TITLE
Update `#!/usr/bin/env bash` references to `#!/bin/bash` [DI-216]

### DIFF
--- a/serialization/protobuf-serializer/generate-source.sh
+++ b/serialization/protobuf-serializer/generate-source.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 # compile proto file to PersonProtos in target/generated-sources
 mvn clean generate-sources

--- a/serialization/protobuf-serializer/runMember.sh
+++ b/serialization/protobuf-serializer/runMember.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 mvn compile exec:java -Dexec.mainClass="Member"


### PR DESCRIPTION
We _mostly_ use `#!/bin/bash` ([~700 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fbin%2Fbash%22&type=code)), but sometimes we use `#!/usr/bin/env bash` ([~500 references](https://github.com/search?q=org%3Ahazelcast+%22%23%21%2Fusr%2Fbin%2Fenv+bash%22&type=code)).

We should be consistent.

Of note - [Google's style guide](https://google.github.io/styleguide/shellguide.html) suggests the same.

Fixes: [DI-216](https://hazelcast.atlassian.net/browse/DI-216)

[DI-216]: https://hazelcast.atlassian.net/browse/DI-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ