### PR TITLE
Prevent usage of `SNAPSHOT` dependencies [DI-293]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,36 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-no-snapshots</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireReleaseDeps>
+                                    <message>Must depend on publically available, released dependencies</message>
+                                    <failWhenParentIsSnapshot>false</failWhenParentIsSnapshot>
+                                    <excludes>
+                                      <!-- 
+                                        Ignore modules inside this project
+                                        This _should_ work out of the box already
+                                        https://issues.apache.org/jira/browse/MENFORCER-304
+                                      -->
+                                      <exclude>com.hazelcast.samples*</exclude>
+                                    </excludes>
+                                </requireReleaseDeps>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
Ensures that only public (non-`SNAPSHOT`) versions of Hazelcast are used.

Fixes: [DI-293](https://hazelcast.atlassian.net/browse/DI-293)

[DI-293]: https://hazelcast.atlassian.net/browse/DI-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ