### PR TITLE
Remove `snapshot-repository` definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,17 +48,6 @@
         <spring.boot.version>3.2.0</spring.boot.version>
     </properties>
 
-    <repositories>
-        <repository>
-            <id>snapshot-repository</id>
-            <name>Maven2 Snapshot Repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-        </repository>
-    </repositories>
-
     <modules>
         <module>clients</module>
         <module>cluster</module>


### PR DESCRIPTION
The usage of `SNAPSHOT` dependencies was removed in https://github.com/hazelcast/hazelcast-code-samples/pull/660, so having a `snapshot-repository` makes no sense.