### PR TITLE
Migrate Jenkins PR builder to GitHub Action [DI-336]

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -38,8 +38,6 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Build and test
-        env:
-            HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
           set ${RUNNER_DEBUG:+-x}
           mvn \

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -20,7 +20,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
   default:
     needs: [check_for_membership]
-    if: needs.check_for_membership.outputs.check-result == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Detect untrusted community PR

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -18,6 +18,8 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Build and test
+        env:
+            HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
           set -x
-          mvn --version --batch-mode --no-transfer-progress --quiet clean package "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" -DskipTests
+          mvn --version --batch-mode --no-transfer-progress --quiet clean package -DskipTests

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -42,7 +42,7 @@ jobs:
         env:
             HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
-          set -x
+          set ${RUNNER_DEBUG:+-x}
           mvn \
             --batch-mode \
             --errors \

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -43,4 +43,11 @@ jobs:
             HAZELCAST_ENTERPRISE_KEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
           set -x
-          mvn --version --batch-mode --no-transfer-progress --quiet clean package -DskipTests
+          mvn \
+            --batch-mode \
+            --errors \
+            --no-transfer-progress \
+            ${RUNNER_DEBUG:+--show-version} \
+           package
+          env:
+            HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -4,31 +4,9 @@ on:
   pull_request:
 
 jobs:
-  check_for_membership:
-    runs-on: ubuntu-latest
-    name: Check membership of given user
-    outputs:
-      check-result: ${{ steps.composite.outputs.check-result }}
-
-    steps:
-      - name: Action for membership check
-        id: composite
-        uses: hazelcast/hazelcast-tpm/membership@main
-        with:
-          organization-name: 'hazelcast'
-          member-name: ${{ github.event.pull_request.head.repo.owner.login }}
-          token: ${{ secrets.GITHUB_TOKEN }}
   default:
-    needs: [check_for_membership]
     runs-on: ubuntu-latest
     steps:
-      - name: Detect untrusted community PR
-        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
-        run: |
-          echo "::error::ERROR: Untrusted external PR. Must be reviewed by Hazelcast" 1>&2;
-          exit 1
-        env:
-          GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java
@@ -45,5 +23,5 @@ jobs:
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
            package
-          env:
-            HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
+        env:
+          HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -20,5 +20,4 @@ jobs:
       - name: Build and test
         run: |
           set -x
-          mvn -V -B clean package "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" -DskipTests
-    
+          mvn --version --batch-mode --no-transfer-progress --quiet clean package "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" -DskipTests

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -21,7 +21,7 @@ jobs:
           organization-name: 'hazelcast'
           member-name: ${{ github.event.pull_request.head.repo.owner.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
-  build:
+  default:
     needs: [check_for_membership]
     if: needs.check_for_membership.outputs.check-result == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,9 +1,6 @@
 name: Builder
 
 on:
-  push:
-    branches:
-      - "master"
   pull_request:
 
 jobs:

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -22,5 +22,5 @@ jobs:
             --errors \
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
-            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" \
+            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" \
            package

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -24,5 +24,5 @@ jobs:
             --errors \
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
-            "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" \
+            "-Dhazelcast.enterprise.license.key=${{ env.HZ_LICENSEKEY }}" \
            package

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -7,9 +7,33 @@ on:
   pull_request:
 
 jobs:
+  check_for_membership:
+    runs-on: ubuntu-latest
+    name: Check membership of given user
+    outputs:
+      check-result: ${{ steps.composite.outputs.check-result }}
+
+    steps:
+      - name: Action for membership check
+        id: composite
+        uses: hazelcast/hazelcast-tpm/membership@main
+        with:
+          organization-name: 'hazelcast'
+          member-name: ${{ github.event.pull_request.head.repo.owner.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
   build:
+    needs: [check_for_membership]
+    if: needs.check_for_membership.outputs.check-result == 'true'
     runs-on: ubuntu-latest
     steps:
+      - name: Detect untrusted community PR
+        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
+        run: |
+          gh pr comment ${{ github.event.number }} \
+            --body "👽 Untrusted non Hazelcast PR, \`${GITHUB_JOB}\` must be [run manually](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          exit 1
+        env:
+          GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,10 +1,10 @@
 name: Builder
 
 on:
-  pull_request:
+  pull_request_target:
 
 jobs:
-  default:
+  pr-builder:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -15,8 +15,6 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Build and test
-        env:
-          HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
           set ${RUNNER_DEBUG:+-x}
           mvn \
@@ -24,5 +22,5 @@ jobs:
             --errors \
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
-            "-Dhazelcast.enterprise.license.key=${{ env.HZ_LICENSEKEY }}" \
+            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" \
            package

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -7,20 +7,16 @@ on:
   pull_request:
 
 jobs:
-  prepare:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Set up Java and JFrog credentials
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: temurin
-  build:
-    runs-on: ubuntu-latest
-    needs: prepare
-    steps:
       - name: Build and test
         run: |
           set -x

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,0 +1,28 @@
+name: Builder
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Set up Java and JFrog credentials
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+  build:
+    runs-on: ubuntu-latest
+    needs: prepare
+    steps:
+      - name: Build and test
+        run: |
+          set -x
+          mvn -V -B clean package "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" -DskipTests
+    

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -15,6 +15,8 @@ jobs:
           java-version: 17
           distribution: temurin
       - name: Build and test
+        env:
+          HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}
         run: |
           set ${RUNNER_DEBUG:+-x}
           mvn \
@@ -22,5 +24,5 @@ jobs:
             --errors \
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
-            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY }}" \
+            "-Dhazelcast.enterprise.license.key=$HZ_LICENSEKEY" \
            package

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -25,8 +25,7 @@ jobs:
       - name: Detect untrusted community PR
         if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
         run: |
-          gh pr comment ${{ github.event.number }} \
-            --body "👽 Untrusted non Hazelcast PR, \`${GITHUB_JOB}\` must be [run manually](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})."
+          echo "::error::ERROR: Untrusted external PR. Must be reviewed by Hazelcast" 1>&2;
           exit 1
         env:
           GH_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -22,6 +22,5 @@ jobs:
             --errors \
             --no-transfer-progress \
             ${RUNNER_DEBUG:+--show-version} \
+            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" \
            package
-        env:
-          HZ_LICENSEKEY: ${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}


### PR DESCRIPTION
This came about at the back of removing Code Samples from Platform releases https://hazelcast.atlassian.net/browse/DI-313

TODO (need help here)
1. Sort out `HZ_LICENSEKEY`. We have these in GH so not sure which one to use
   - HAZELCAST_ENTERPRISE_KEY (may be start with this?)
   - HAZELCAST_ENTERPRISE_KEY_V7 (this will future proof perhaps?)
4. Limit who runs this via the action (checking for org membership) or via the GitHub repo config?
5. Remove `-DskipTests` once above is sorted

Fixes: [DI-336](https://hazelcast.atlassian.net/browse/DI-336)

[DI-336]: https://hazelcast.atlassian.net/browse/DI-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ