### PR TITLE
Don't log environment variables if debugging isn't enabled

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -16,7 +16,7 @@ jobs:
           distribution: temurin
       - name: Build and test
         run: |
-          set ${RUNNER_DEBUG:+-x}
+          ${RUNNER_DEBUG:+set -x}
           mvn \
             --batch-mode \
             --errors \


### PR DESCRIPTION
If debugging _isn't_ enabled, the command evaluated to `set` and just [printed all the variables](https://github.com/hazelcast/hazelcast-code-samples/actions/runs/11782852379/job/32818798295) which was useless.