### PR TITLE
Add Maven caching to PR Builder [DI-336]

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           java-version: 17
           distribution: temurin
+          cache: maven
       - name: Build and test
         run: |
           set ${RUNNER_DEBUG:+-x}


### PR DESCRIPTION
Because it's `pull_request_target`, the cache _should_ be accessible to improve build times between branches.

To be tested post-merge.