### PR TITLE
Add PR membership check  [DI-336]

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
   pr-builder:
     runs-on: ubuntu-latest
-    needs: [check_for_membership]
+    needs: check_for_membership
     steps:
       - name: Detect untrusted community PR
         if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -36,4 +36,10 @@ jobs:
       - name: Build and test
         run: |
           ${RUNNER_DEBUG:+set -x}
-          ls -al
+          mvn \
+            --batch-mode \
+            --errors \
+            --no-transfer-progress \
+            ${RUNNER_DEBUG:+--show-version} \
+            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" \
+           package

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
           organization-name: 'hazelcast'
-          member-name: ${{ github.event.pull_request.head.repo.owner.login }}
+          member-name: ${{ github.actor }}
           token: ${{ secrets.GH_TOKEN }}
   pr-builder:
     runs-on: ubuntu-latest

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -4,9 +4,28 @@ on:
   pull_request_target:
 
 jobs:
+  check_for_membership:
+    runs-on: ubuntu-latest
+    name: Check PR author membership
+    outputs:
+      check-result: ${{ steps.composite.outputs.check-result }}
+    steps: 
+      - name: Action for membership check
+        id: composite
+        uses: hazelcast/hazelcast-tpm/membership@main
+        with:
+          organization-name: 'hazelcast'
+          member-name: ${{ github.event.pull_request.head.repo.owner.login }}
+          token: ${{ secrets.GH_TOKEN }}
   pr-builder:
     runs-on: ubuntu-latest
+    needs: [check_for_membership]
     steps:
+      - name: Detect untrusted community PR
+        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
+        run: |
+          echo "::error::ERROR: Untrusted external PR. Must be reviewed and executed by Hazelcast" 1>&2;
+          exit 1
       - name: Checkout Code
         uses: actions/checkout@v4
       - name: Set up Java
@@ -17,10 +36,4 @@ jobs:
       - name: Build and test
         run: |
           ${RUNNER_DEBUG:+set -x}
-          mvn \
-            --batch-mode \
-            --errors \
-            --no-transfer-progress \
-            ${RUNNER_DEBUG:+--show-version} \
-            "-Dhazelcast.enterprise.license.key=${{ secrets.HAZELCAST_ENTERPRISE_KEY_V7 }}" \
-           package
+          ls -al


### PR DESCRIPTION
Follow-up from https://github.com/hazelcast/hazelcast-code-samples/pull/674

I tested this:

INTERNAL user: https://github.com/hazelcast/pr-test/pull/1 (passes)
![image](https://github.com/user-attachments/assets/4a98e1b5-bb3c-44d6-8725-6c41dcae7b08)


EXTERNAL user: https://github.com/hazelcast/pr-test/pull/2 (fails)

![image](https://github.com/user-attachments/assets/797ba628-1862-4e6f-a158-8eb3979f72be)
![image](https://github.com/user-attachments/assets/9a584b38-04ea-4d26-b0d8-6190a79a2a3c)

After merge, enable Actions again https://github.com/hazelcast/hazelcast-code-samples/settings/actions

NOTE: will need to merge without PR builder as its disabled. I will retest again after merge
