### PR TITLE
Disable SpringHibernate2lcApplicationTest [DI-336]

### DIFF
--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
@@ -86,13 +86,6 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
             </plugin>
-            <plugin>
-                <!-- See https://hazelcast.atlassian.net/browse/DI-338 -->
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <skipTests>true</skipTests>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
@@ -86,6 +86,12 @@
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <version>${spring.boot.version}</version>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/pom.xml
@@ -87,6 +87,7 @@
                 <version>${spring.boot.version}</version>
             </plugin>
             <plugin>
+                <!-- See https://hazelcast.atlassian.net/browse/DI-338 -->
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <skipTests>true</skipTests>

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
@@ -9,7 +9,6 @@ import org.hibernate.Session;
 import org.hibernate.Version;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
-import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +21,6 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
-@Ignore("Need to release plugins for 4.0 first")
 class SpringHibernate2lcApplicationTest {
 
 	private static Logger logger = LoggerFactory.getLogger(SpringHibernate2lcApplicationTest.class);

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@Ignore("Need to release plugins for 4.0 first")
 class SpringHibernate2lcApplicationTest {
 
 	private static Logger logger = LoggerFactory.getLogger(SpringHibernate2lcApplicationTest.class);

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
@@ -9,6 +9,7 @@ import org.hibernate.Session;
 import org.hibernate.Version;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
+++ b/hazelcast-integration/spring-hibernate-2ndlevel-cache/src/test/java/com/hazelcast/hibernate/springhibernate2lc/SpringHibernate2lcApplicationTest.java
@@ -9,6 +9,7 @@ import org.hibernate.Session;
 import org.hibernate.Version;
 import org.hibernate.stat.Statistics;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Disabled;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import java.util.Collection;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@Disabled("See https://hazelcast.atlassian.net/browse/DI-338")
 class SpringHibernate2lcApplicationTest {
 
 	private static Logger logger = LoggerFactory.getLogger(SpringHibernate2lcApplicationTest.class);


### PR DESCRIPTION
Disable test temporarily until [DI-338](https://hazelcast.atlassian.net/browse/DI-338) is fixed

We have migrated Code Samples PR builder to GitHub (https://github.com/hazelcast/hazelcast-code-samples/pull/674) and Hazelcast is activating Azure identity provider (likely as GH hosted runners run in Azure) which results in the test hanging by continuously attempting to connect to HZ cluster (which likely failed to start)

The test emits Azure warning in the build log:

```
2024-11-12T13:09:27.618Z  INFO 3599 --- [spring-hazelcast-hibernate-2lc] [           main] com.hazelcast.core.LifecycleService      : [10.1.0.75]:5701 [dev] [5.5.0] [10.1.0.75]:5701 is STARTING
2024-11-12T13:09:27.654Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.azure.AzureDiscoveryStrategy         : No Azure credentials found! Starting standalone. To use Hazelcast Azure discovery, configure properties (client-id, tenant-id, client-secret) or assign a managed identity to the Azure Compute instance
2024-11-12T13:09:32.905Z  INFO 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.internal.cluster.ClusterService      : [10.1.0.75]:5701 [dev] [5.5.0] 
```

A little later the test hangs repeatedly connecting to cluster 

```
2024-11-12T13:09:33.847Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.azure.AzureDiscoveryStrategy         : No Azure credentials found! Starting standalone. To use Hazelcast Azure discovery, configure properties (client-id, tenant-id, client-secret) or assign a managed identity to the Azure Compute instance
2024-11-12T13:09:33.847Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.c.i.c.ClientConnectionManager        : hz.client_1 [dev] [5.5.0] Unable to get live cluster connection, retry in 2000 ms, attempt: 1, cluster connect timeout: 2147483647 ms, max backoff: 35000 ms
2024-11-12T13:09:35.855Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.c.i.c.ClientConnectionManager        : hz.client_1 [dev] [5.5.0] Unable to get live cluster connection, retry in 3000 ms, attempt: 2, cluster connect timeout: 2147483647 ms, max backoff: 35000 ms
2024-11-12T13:09:38.866Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.c.i.c.ClientConnectionManager        : hz.client_1 [dev] [5.5.0] Unable to get live cluster connection, retry in 4500 ms, attempt: 3, cluster connect timeout: 2147483647 ms, max backoff: 35000 ms
2024-11-12T13:09:43.376Z  WARN 3599 --- [spring-hazelcast-hibernate-2lc] [           main] c.h.c.i.c.ClientConnectionManager        : hz.client_1 [dev] [5.5.0] Unable to g
```
This might take effort to fix so disabling for now is the simplest option


Note: Tried using `@ignore(...)` on the test but didn't take effect for some reason so resorted to disabling via POM. This is the only test at the moment 

[DI-338]: https://hazelcast.atlassian.net/browse/DI-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ