### PR TITLE
Move Spring Boot Session replication with WebFilter back [DEX-297]

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -37,6 +37,7 @@
     </properties>
 
     <modules>
+        <module>spring-boot-session-replication-webfilter</module>
         <module>spring-configuration</module>
         <module>spring-data-hazelcast-chemistry-sample</module>
         <module>spring-data-jpa-hazelcast-migration</module>

--- a/spring/spring-boot-session-replication-webfilter/README.adoc
+++ b/spring/spring-boot-session-replication-webfilter/README.adoc
@@ -1,0 +1,1 @@
+See the link:https://docs.hazelcast.com/tutorials/springboot-webfilter-session-replication[tutorial].

--- a/spring/spring-boot-session-replication-webfilter/pom.xml
+++ b/spring/spring-boot-session-replication-webfilter/pom.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.hazelcast.samples</groupId>
+    <artifactId>spring-boot-session-replication-webfilter</artifactId>
+    <name>Spring Boot: Hazelcast embedded for Session Replication using WebFilter</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>5.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-wm</artifactId>
+            <version>5.1-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring/spring-boot-session-replication-webfilter/src/main/java/com/hazelcast/springboot/http/Application.java
+++ b/spring/spring-boot-session-replication-webfilter/src/main/java/com/hazelcast/springboot/http/Application.java
@@ -1,0 +1,32 @@
+package com.hazelcast.springboot.http;
+
+import com.hazelcast.config.Config;
+import com.hazelcast.core.HazelcastInstance;
+import com.hazelcast.web.WebFilter;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Properties;
+
+@SpringBootApplication
+public class Application {
+
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+
+    @Bean
+    public Config config() {
+        return new Config();
+    }
+
+    @Bean
+    public WebFilter webFilter(HazelcastInstance hazelcastInstance) {
+        Properties properties = new Properties();
+        properties.put("instance-name", hazelcastInstance.getName());
+        properties.put("sticky-session", "false");
+
+        return new WebFilter(properties);
+    }
+}

--- a/spring/spring-boot-session-replication-webfilter/src/main/java/com/hazelcast/springboot/http/WebController.java
+++ b/spring/spring-boot-session-replication-webfilter/src/main/java/com/hazelcast/springboot/http/WebController.java
@@ -1,0 +1,28 @@
+package com.hazelcast.springboot.http;
+
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/")
+public class WebController {
+
+    @ModelAttribute("sessionId")
+    public String sessionId(final HttpSession session) {
+        return session.getId();
+    }
+
+    @RequestMapping(value = "/")
+    public String index(HttpSession httpSession) {
+        Integer hits = (Integer) httpSession.getAttribute("hits");
+        if (hits == null) {
+            hits = 0;
+        }
+        httpSession.setAttribute("hits", ++hits);
+
+        return "index";
+    }
+
+}

--- a/spring/spring-boot-session-replication-webfilter/src/main/resources/templates/index.html
+++ b/spring/spring-boot-session-replication-webfilter/src/main/resources/templates/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+	<body>
+		<h3>Session Id</h3>
+		<p th:text="${sessionId}"/>
+		<h3>Hits</h3>
+		<p th:text="${session.hits}"/>
+	</body>
+</html>

--- a/spring/spring-boot-session-replication-webfilter/src/test/java/com/hazelcast/springboot/http/ApplicationTest.java
+++ b/spring/spring-boot-session-replication-webfilter/src/test/java/com/hazelcast/springboot/http/ApplicationTest.java
@@ -1,0 +1,74 @@
+package com.hazelcast.springboot.http;
+
+import com.hazelcast.config.Config;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ApplicationTest {
+
+    @Test
+    public void testSessionReplication() {
+        // given
+        String port1 = startApplication();
+        String port2 = startApplication();
+
+        // when
+        ResponseEntity<?> response1 = makeRequest(port1);
+        String sessionId = extractCookie(response1, "JSESSIONID");
+        String hazelcastSessionId = extractCookie(response1, "hazelcast.sessionId");
+        ResponseEntity<?> response2 = makeRequest(port2, sessionId, hazelcastSessionId);
+
+        // then
+        String body = response2.getBody().toString();
+        assertThat(body).contains(hazelcastSessionId);
+        assertThat(body).contains("<p>2</p>");
+    }
+
+    private static String startApplication() {
+        return new SpringApplicationBuilder(TestApplication.class)
+                .properties("server.port=0", "spring.main.allow-bean-definition-overriding=true")
+                .run()
+                .getEnvironment()
+                .getProperty("local.server.port");
+    }
+
+    private String extractCookie(ResponseEntity<?> response, String cookie) {
+        return response.getHeaders().get("Set-Cookie").stream()
+                .filter(s -> s.contains(cookie))
+                .map(s -> s.split(";")[0])
+                .map(s -> s.substring(cookie.length() + 1))
+                .findFirst().orElse(null);
+    }
+
+    private static ResponseEntity<?> makeRequest(String port) {
+        return makeRequest(port, null, null);
+    }
+
+    private static ResponseEntity<?> makeRequest(String port, String sessionId, String hazelcastSessionId) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        if (sessionId != null || hazelcastSessionId != null) {
+            headers.add("Cookie", String.format("JSESSIONID=%s;hazelcast.sessionId=%s", sessionId, hazelcastSessionId));
+        }
+        return restTemplate.exchange("http://localhost:" + port, HttpMethod.GET, new HttpEntity<>(headers), String.class);
+    }
+
+    public static class TestApplication extends Application {
+
+        @Bean
+        public Config config() {
+            Config config = super.config(); // Keep the test sync with the published content.
+            config.getNetworkConfig().getJoin().getMulticastConfig().setEnabled(true);
+            return config;
+        }
+
+    }
+}


### PR DESCRIPTION
Some code samples were previously moved out into separate repositories. This makes them hard to maintain.

Changes:
- updates to Hazelcast 5.5.0 and Spring Boot 3.4.0
- added hazelcast-wm (previously this sample was using hazelcast-all that is no longer available)
- fixed how thymeleaf access to session id
- improved test

TODO
This sample uses hazelcast-wm library. Spring uses the jakarta namespace in the latest version, we updated to jakarta namespace in 5.1-SNAPSHOT.

We need
- update the hazelcast-wm version to 6.0 (updating to jakarta namespace is major breaking change)
- do a release