### PR TITLE
Move Spring Boot Caching with Hazelcast Cache Manager back [DEX-298]

### DIFF
--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -37,6 +37,7 @@
     </properties>
 
     <modules>
+        <module>spring-boot-caching-hazelcast-cache-manager</module>
         <module>spring-configuration</module>
         <module>spring-data-hazelcast-chemistry-sample</module>
         <module>spring-data-jpa-hazelcast-migration</module>

--- a/spring/spring-boot-caching-hazelcast-cache-manager/README.adoc
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/README.adoc
@@ -1,0 +1,1 @@
+See the link:https://docs.hazelcast.com/tutorials/caching-springboot[tutorial].

--- a/spring/spring-boot-caching-hazelcast-cache-manager/pom.xml
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.0</version>
+        <relativePath/> <!-- lookup parent from repository -->
+    </parent>
+
+    <groupId>com.hazelcast.samples</groupId>
+    <artifactId>spring-boot-caching-hazelcast-cache-manager</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>Spring Boot Caching with Hazelcast Cache Manager</name>
+
+    <properties>
+        <hazelcast.version>5.5.0</hazelcast.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+        <!-- The hazelcast-spring dependency is required for com.hazelcast.spring.cache.HazelcastCacheManager-->
+        <dependency>
+            <groupId>com.hazelcast</groupId>
+            <artifactId>hazelcast-spring</artifactId>
+            <version>${hazelcast.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/Application.java
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/Application.java
@@ -1,0 +1,31 @@
+/*
+ *
+ *  Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package com.hazelcast.springboot.caching;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+
+@SpringBootApplication
+@EnableCaching
+public class Application {
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
+}

--- a/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/BookController.java
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/BookController.java
@@ -1,0 +1,23 @@
+package com.hazelcast.springboot.caching;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/books")
+public class BookController {
+
+    private final BookService bookService;
+
+    BookController(BookService bookService) {
+        this.bookService = bookService;
+    }
+
+    @GetMapping("/{isbn}")
+    public String getBookNameByIsbn(@PathVariable("isbn") String isbn) {
+        return bookService.getBookNameByIsbn(isbn);
+    }
+}
+

--- a/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/BookService.java
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/src/main/java/com/hazelcast/springboot/caching/BookService.java
@@ -1,0 +1,23 @@
+package com.hazelcast.springboot.caching;
+
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BookService {
+    @Cacheable("books")
+    public String getBookNameByIsbn(String isbn) {
+        return findBookInSlowSource(isbn);
+    }
+
+    private String findBookInSlowSource(String isbn) {
+        // some long processing
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+        return "Sample Book Name, isbn: " + isbn;
+    }
+}

--- a/spring/spring-boot-caching-hazelcast-cache-manager/src/main/resources/hazelcast.yaml
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/src/main/resources/hazelcast.yaml
@@ -1,0 +1,5 @@
+hazelcast:
+  network:
+    join:
+      multicast:
+        enabled: true

--- a/spring/spring-boot-caching-hazelcast-cache-manager/src/test/java/com/hazelcast/springboot/caching/ApplicationTest.java
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/src/test/java/com/hazelcast/springboot/caching/ApplicationTest.java
@@ -1,0 +1,38 @@
+package com.hazelcast.springboot.caching;
+
+import com.hazelcast.core.HazelcastInstance;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+public class ApplicationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private HazelcastInstance hazelcastInstance;
+
+    @Test
+    public void useCachedValue() {
+        // given
+        String isbn = "12345";
+        String cachedValue = "cached-value";
+        hazelcastInstance.getMap("books").put(isbn, cachedValue);
+
+        // when
+        String response = restTemplate.getForObject(String.format("http://localhost:%s/books/%s", port, isbn), String.class);
+
+        // then
+        assertThat(response).isEqualTo(cachedValue);
+    }
+}


### PR DESCRIPTION
Some code samples were previously moved out into separate repositories. This makes them hard to maintain.

Changes:
- added hazelcast-spring dependency (needed because we no longer use hazelcast-all)