### PR TITLE
Remove duplicate Maven properties

### DIFF
--- a/clients/basic/pom.xml
+++ b/clients/basic/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/clients/client-connection-strategy/pom.xml
+++ b/clients/client-connection-strategy/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 

--- a/clients/client-exponential-backoff/pom.xml
+++ b/clients/client-exponential-backoff/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/clients/client-labels/pom.xml
+++ b/clients/client-labels/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/clients/client-near-cache/pom.xml
+++ b/clients/client-near-cache/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/clients/client-rest/pom.xml
+++ b/clients/client-rest/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/clients/client-statistics/pom.xml
+++ b/clients/client-statistics/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/clients/user-code-deployment/pom.xml
+++ b/clients/user-code-deployment/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/clients/user-code-deployment/user-code-deployment-client/pom.xml
+++ b/clients/user-code-deployment/user-code-deployment-client/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/clients/user-code-deployment/user-code-deployment-member/pom.xml
+++ b/clients/user-code-deployment/user-code-deployment-member/pom.xml
@@ -14,6 +14,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cluster-split-brain-protection-xml/pom.xml
+++ b/cluster-split-brain-protection-xml/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/cluster-split-brain-protection/pom.xml
+++ b/cluster-split-brain-protection/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/cluster-state/pom.xml
+++ b/cluster-state/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/cluster/pom.xml
+++ b/cluster/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/cp-subsystem/cp-atomiclong/pom.xml
+++ b/cp-subsystem/cp-atomiclong/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/cp-atomicreference/pom.xml
+++ b/cp-subsystem/cp-atomicreference/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/cp-countdownlatch/pom.xml
+++ b/cp-subsystem/cp-countdownlatch/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/cp-listeners/pom.xml
+++ b/cp-subsystem/cp-listeners/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/cp-map/pom.xml
+++ b/cp-subsystem/cp-map/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/cp-semaphore/pom.xml
+++ b/cp-subsystem/cp-semaphore/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-auto-release-on-session-close/pom.xml
+++ b/cp-subsystem/fenced-lock-auto-release-on-session-close/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-auto-release-on-shutdown/pom.xml
+++ b/cp-subsystem/fenced-lock-auto-release-on-shutdown/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-basic-usage/pom.xml
+++ b/cp-subsystem/fenced-lock-basic-usage/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-force-release/pom.xml
+++ b/cp-subsystem/fenced-lock-force-release/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-lock-ownership-lost-exception/pom.xml
+++ b/cp-subsystem/fenced-lock-lock-ownership-lost-exception/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-monotonic-fencing-tokens/pom.xml
+++ b/cp-subsystem/fenced-lock-monotonic-fencing-tokens/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-non-reentrant-mutex/pom.xml
+++ b/cp-subsystem/fenced-lock-non-reentrant-mutex/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock-using-fencing-tokens/pom.xml
+++ b/cp-subsystem/fenced-lock-using-fencing-tokens/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/fenced-lock/pom.xml
+++ b/cp-subsystem/fenced-lock/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/pom.xml
+++ b/cp-subsystem/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/cp-subsystem/remove-crashed-cp-members-automatically/pom.xml
+++ b/cp-subsystem/remove-crashed-cp-members-automatically/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/remove-crashed-cp-members-manually/pom.xml
+++ b/cp-subsystem/remove-crashed-cp-members-manually/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/restart-cp-subsystem/pom.xml
+++ b/cp-subsystem/restart-cp-subsystem/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/start-cp-subsystem-1/pom.xml
+++ b/cp-subsystem/start-cp-subsystem-1/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/cp-subsystem/start-cp-subsystem-2/pom.xml
+++ b/cp-subsystem/start-cp-subsystem-2/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/demo/pom.xml
+++ b/demo/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/distributed-collections/blockingqueue/pom.xml
+++ b/distributed-collections/blockingqueue/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/boundedblockingqueue/pom.xml
+++ b/distributed-collections/boundedblockingqueue/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/itemlisteners/pom.xml
+++ b/distributed-collections/itemlisteners/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/list/pom.xml
+++ b/distributed-collections/list/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/pom.xml
+++ b/distributed-collections/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/distributed-collections/queuestore/pom.xml
+++ b/distributed-collections/queuestore/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/ringbuffer/pom.xml
+++ b/distributed-collections/ringbuffer/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/ringbufferstore/pom.xml
+++ b/distributed-collections/ringbufferstore/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-collections/set/pom.xml
+++ b/distributed-collections/set/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/basic-executor/pom.xml
+++ b/distributed-executor/basic-executor/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/durable-executor-service/pom.xml
+++ b/distributed-executor/durable-executor-service/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/executing-on-all-members/pom.xml
+++ b/distributed-executor/executing-on-all-members/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/executing-on-key-owner/pom.xml
+++ b/distributed-executor/executing-on-key-owner/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/executing-on-lite-members/pom.xml
+++ b/distributed-executor/executing-on-lite-members/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/executing-on-specific-member/pom.xml
+++ b/distributed-executor/executing-on-specific-member/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/execution-callback/pom.xml
+++ b/distributed-executor/execution-callback/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/futures/pom.xml
+++ b/distributed-executor/futures/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/pom.xml
+++ b/distributed-executor/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/distributed-executor/scale-out/pom.xml
+++ b/distributed-executor/scale-out/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scale-up/pom.xml
+++ b/distributed-executor/scale-up/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduled-executor-retrieve-all-tasks/pom.xml
+++ b/distributed-executor/scheduled-executor-retrieve-all-tasks/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduled-executor-retrieve-lost-future/pom.xml
+++ b/distributed-executor/scheduled-executor-retrieve-lost-future/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduling-named-task/pom.xml
+++ b/distributed-executor/scheduling-named-task/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduling-on-key-owner-durable/pom.xml
+++ b/distributed-executor/scheduling-on-key-owner-durable/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduling-on-specific-member/pom.xml
+++ b/distributed-executor/scheduling-on-specific-member/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-executor/scheduling-stateful-task/pom.xml
+++ b/distributed-executor/scheduling-stateful-task/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/backup/pom.xml
+++ b/distributed-map/backup/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/distributed-map/basics/pom.xml
+++ b/distributed-map/basics/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/continuous-query-cache/pom.xml
+++ b/distributed-map/continuous-query-cache/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/distributed-map/continuous-query/pom.xml
+++ b/distributed-map/continuous-query/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/criteria-api/pom.xml
+++ b/distributed-map/criteria-api/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/custom-attributes/pom.xml
+++ b/distributed-map/custom-attributes/pom.xml
@@ -15,6 +15,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/data-locality/pom.xml
+++ b/distributed-map/data-locality/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/entry-listener/pom.xml
+++ b/distributed-map/entry-listener/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/entry-processor/pom.xml
+++ b/distributed-map/entry-processor/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/distributed-map/entrystore/pom.xml
+++ b/distributed-map/entrystore/pom.xml
@@ -15,6 +15,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/eviction/pom.xml
+++ b/distributed-map/eviction/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/fast-aggregations/pom.xml
+++ b/distributed-map/fast-aggregations/pom.xml
@@ -15,6 +15,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/hashcode-and-equals/pom.xml
+++ b/distributed-map/hashcode-and-equals/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/in-memory-format/pom.xml
+++ b/distributed-map/in-memory-format/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/index/pom.xml
+++ b/distributed-map/index/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/json/pom.xml
+++ b/distributed-map/json/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/locking/pom.xml
+++ b/distributed-map/locking/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/map-interceptor/pom.xml
+++ b/distributed-map/map-interceptor/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/mapstore/pom.xml
+++ b/distributed-map/mapstore/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/distributed-map/multi-map/pom.xml
+++ b/distributed-map/multi-map/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/nearcache/pom.xml
+++ b/distributed-map/nearcache/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/distributed-map/paging-predicate/pom.xml
+++ b/distributed-map/paging-predicate/pom.xml
@@ -18,6 +18,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/partition-lost-listener/pom.xml
+++ b/distributed-map/partition-lost-listener/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/pom.xml
+++ b/distributed-map/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/distributed-map/projections/pom.xml
+++ b/distributed-map/projections/pom.xml
@@ -15,6 +15,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/query-collections/pom.xml
+++ b/distributed-map/query-collections/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-map/sqlquery/pom.xml
+++ b/distributed-map/sqlquery/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-primitives/cardinalityestimator/pom.xml
+++ b/distributed-primitives/cardinalityestimator/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-primitives/flake-id-generator/pom.xml
+++ b/distributed-primitives/flake-id-generator/pom.xml
@@ -16,6 +16,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-primitives/pn-counter/pom.xml
+++ b/distributed-primitives/pn-counter/pom.xml
@@ -16,6 +16,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-primitives/pom.xml
+++ b/distributed-primitives/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/distributed-topic/basic-pub-sub/pom.xml
+++ b/distributed-topic/basic-pub-sub/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-topic/pom.xml
+++ b/distributed-topic/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/distributed-topic/reliable-topic/pom.xml
+++ b/distributed-topic/reliable-topic/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/distributed-topic/scaling/pom.xml
+++ b/distributed-topic/scaling/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/auditlog/pom.xml
+++ b/enterprise/auditlog/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <exec.mainClass>MainDeclarativConfig</exec.mainClass>
     </properties>
 

--- a/enterprise/client-custom-credentials/pom.xml
+++ b/enterprise/client-custom-credentials/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/client-failover-cluster/pom.xml
+++ b/enterprise/client-failover-cluster/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/client-ssl/pom.xml
+++ b/enterprise/client-ssl/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>
 

--- a/enterprise/client-token-credentials/pom.xml
+++ b/enterprise/client-token-credentials/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/hd-imap/pom.xml
+++ b/enterprise/hd-imap/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-client/pom.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-client/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/enterprise/hd-memory-client-server/hd-memory-examples-server/pom.xml
+++ b/enterprise/hd-memory-client-server/hd-memory-examples-server/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/enterprise/hd-memory-client-server/pom.xml
+++ b/enterprise/hd-memory-client-server/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/enterprise/hidensity-cache/pom.xml
+++ b/enterprise/hidensity-cache/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jsr107.api.version>1.1.1</jsr107.api.version>
     </properties>

--- a/enterprise/hot-restart/pom.xml
+++ b/enterprise/hot-restart/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/enterprise/kerberos-authentication-docker-compose/timestamp-client/pom.xml
+++ b/enterprise/kerberos-authentication-docker-compose/timestamp-client/pom.xml
@@ -11,7 +11,6 @@
     <name>Hazelcast timestamp client</name>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/enterprise/ldap-authentication/pom.xml
+++ b/enterprise/ldap-authentication/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.org.apache.ds>2.0.0-M24</version.org.apache.ds>
     </properties>
 

--- a/enterprise/pcf-tls-integration/pom.xml
+++ b/enterprise/pcf-tls-integration/pom.xml
@@ -6,7 +6,6 @@
 
     <groupId>com.hazelcast.samples</groupId>
     <artifactId>pcf-tls-integration</artifactId>
-    <version>0.1-SNAPSHOT</version>
     <description>A sample Spring Boot Application to demonstrate integration with Hazelcast for PCF with TLS enabled</description>
 
     <parent>
@@ -20,7 +19,6 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
 
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <!-- adding SpringBoot BOM -->

--- a/enterprise/pom.xml
+++ b/enterprise/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/enterprise/security-interceptor/pom.xml
+++ b/enterprise/security-interceptor/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/simple-authentication/pom.xml
+++ b/enterprise/simple-authentication/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/socket-interceptor/pom.xml
+++ b/enterprise/socket-interceptor/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/ssl/pom.xml
+++ b/enterprise/ssl/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/symmetric-encryption/pom.xml
+++ b/enterprise/symmetric-encryption/pom.xml
@@ -16,6 +16,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/enterprise/tiered-store/pom.xml
+++ b/enterprise/tiered-store/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/tls-rbac-demo/pom.xml
+++ b/enterprise/tls-rbac-demo/pom.xml
@@ -17,7 +17,6 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/enterprise/user-code-namespaces/user-code-namespaces-client/pom.xml
+++ b/enterprise/user-code-namespaces/user-code-namespaces-client/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/user-code-namespaces/user-code-namespaces-member/pom.xml
+++ b/enterprise/user-code-namespaces/user-code-namespaces-member/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/wan-replication/basic-sample/pom.xml
+++ b/enterprise/wan-replication/basic-sample/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/enterprise/wan-replication/interactive-sample/pom.xml
+++ b/enterprise/wan-replication/interactive-sample/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/enterprise/wan-replication/simulating-max-idle/pom.xml
+++ b/enterprise/wan-replication/simulating-max-idle/pom.xml
@@ -14,7 +14,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/generic-record/generic-record-client/pom.xml
+++ b/generic-record/generic-record-client/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     
     <artifactId>generic-recod-client</artifactId>

--- a/generic-record/generic-record-cluster/pom.xml
+++ b/generic-record/generic-record-cluster/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/generic-record/pom.xml
+++ b/generic-record/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/dynacache/pom.xml
+++ b/hazelcast-integration/dynacache/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/eureka/pom.xml
+++ b/hazelcast-integration/eureka/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/hazelcast-integration/filter-based-session-replication/pom.xml
+++ b/hazelcast-integration/filter-based-session-replication/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
+++ b/hazelcast-integration/hibernate-2ndlevel-cache/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <hibernate.version>6.1.3.Final</hibernate.version>
         <h2db.version>2.2.224</h2db.version>
     </properties>

--- a/hazelcast-integration/hikari-connection-pool/pom.xml
+++ b/hazelcast-integration/hikari-connection-pool/pom.xml
@@ -16,10 +16,6 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/jca-ra/pom.xml
+++ b/hazelcast-integration/jca-ra/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.jboss.maven.plugin>7.1.1.Final</version.jboss.maven.plugin>
         <version.jboss.spec.javaee.6.0>3.0.2.Final</version.jboss.spec.javaee.6.0>

--- a/hazelcast-integration/kubernetes/pom.xml
+++ b/hazelcast-integration/kubernetes/pom.xml
@@ -37,7 +37,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/hazelcast-integration/kubernetes/samples/pom.xml
+++ b/hazelcast-integration/kubernetes/samples/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
+++ b/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <docker.image.prefix>${project.artifactId}</docker.image.prefix>
 

--- a/hazelcast-integration/manager-based-session-replication/pom.xml
+++ b/hazelcast-integration/manager-based-session-replication/pom.xml
@@ -7,7 +7,6 @@
 
     <artifactId>manager-based-session-replication</artifactId>
     <groupId>com</groupId>
-    <version>0.1-SNAPSHOT</version>
     <name>Manager Based Session Replication Example</name>
     <url>http://maven.apache.org</url>
 
@@ -20,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
@@ -4,7 +4,6 @@
     <artifactId>ocp-demo-frontend</artifactId>
     <name>ocp-demo-frontend</name>
     <packaging>jar</packaging>
-    <version>0.1-SNAPSHOT</version>
 
     <parent>
         <artifactId>client-apps</artifactId>
@@ -16,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/hazelcast-integration/openshift/client-apps/ocp-entry-processor/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/ocp-entry-processor/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/hazelcast-integration/openshift/client-apps/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <spring.version>4.3.7.RELEASE</spring.version>

--- a/hazelcast-integration/pom.xml
+++ b/hazelcast-integration/pom.xml
@@ -33,7 +33,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/helper/pom.xml
+++ b/helper/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jcache-1.1/pom.xml
+++ b/jcache-1.1/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/jcache-1.1/times-table/jcache-common/pom.xml
+++ b/jcache-1.1/times-table/jcache-common/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/jcache-1.1/times-table/jcache-server/pom.xml
+++ b/jcache-1.1/times-table/jcache-server/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jcache-1.1/times-table/jcache-spring/pom.xml
+++ b/jcache-1.1/times-table/jcache-spring/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jcache-1.1/times-table/jcache-standard/pom.xml
+++ b/jcache-1.1/times-table/jcache-standard/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jcache-1.1/times-table/pom.xml
+++ b/jcache-1.1/times-table/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- these versions are set by the build profile, see the bottom of this file -->
         <hazelcast.version>${profile.hazelcast.version}</hazelcast.version>

--- a/jcache/pom.xml
+++ b/jcache/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jsr107.api.version>1.1.1</jsr107.api.version>
     </properties>

--- a/jet/cdc/pom.xml
+++ b/jet/cdc/pom.xml
@@ -61,6 +61,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/co-group/pom.xml
+++ b/jet/co-group/pom.xml
@@ -32,6 +32,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/early-window-results/pom.xml
+++ b/jet/early-window-results/pom.xml
@@ -44,6 +44,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/elastic/pom.xml
+++ b/jet/elastic/pom.xml
@@ -40,6 +40,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/enrichment/pom.xml
+++ b/jet/enrichment/pom.xml
@@ -32,6 +32,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/event-journal/pom.xml
+++ b/jet/event-journal/pom.xml
@@ -39,6 +39,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/fault-tolerance/pom.xml
+++ b/jet/fault-tolerance/pom.xml
@@ -30,6 +30,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/files-cloud/pom.xml
+++ b/jet/files-cloud/pom.xml
@@ -53,6 +53,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/files/pom.xml
+++ b/jet/files/pom.xml
@@ -90,6 +90,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/grpc/pom.xml
+++ b/jet/grpc/pom.xml
@@ -76,6 +76,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/hadoop/pom.xml
+++ b/jet/hadoop/pom.xml
@@ -140,6 +140,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/hazelcast-connectors/pom.xml
+++ b/jet/hazelcast-connectors/pom.xml
@@ -41,6 +41,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/hello-world/pom.xml
+++ b/jet/hello-world/pom.xml
@@ -48,6 +48,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/jdbc/pom.xml
+++ b/jet/jdbc/pom.xml
@@ -40,6 +40,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/jms/pom.xml
+++ b/jet/jms/pom.xml
@@ -49,7 +49,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <artemis.version>2.29.0</artemis.version>
     </properties>
 </project>

--- a/jet/job-management/pom.xml
+++ b/jet/job-management/pom.xml
@@ -31,6 +31,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/kafka-connect/pom.xml
+++ b/jet/kafka-connect/pom.xml
@@ -5,7 +5,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.hazelcast</groupId>
     <artifactId>jet-kafka-connect</artifactId>
-    <version>0.1-SNAPSHOT</version>
     <parent>
         <groupId>com.hazelcast.samples.jet</groupId>
         <artifactId>jet</artifactId>
@@ -13,7 +12,6 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
     </properties>

--- a/jet/kafka/pom.xml
+++ b/jet/kafka/pom.xml
@@ -32,7 +32,6 @@
         <confluent.version>5.5.3</confluent.version>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <repositories>

--- a/jet/mongodb/pom.xml
+++ b/jet/mongodb/pom.xml
@@ -34,9 +34,7 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <java-version>17</java-version>
         <testcontainers.version>1.18.0</testcontainers.version>
         <log4j2.version>2.20.0</log4j2.version>
     </properties>

--- a/jet/pattern-matching/pom.xml
+++ b/jet/pattern-matching/pom.xml
@@ -31,6 +31,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/pom.xml
+++ b/jet/pom.xml
@@ -72,7 +72,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/jet/protobuf/pom.xml
+++ b/jet/protobuf/pom.xml
@@ -67,6 +67,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/python/pom.xml
+++ b/jet/python/pom.xml
@@ -61,6 +61,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/return-results/pom.xml
+++ b/jet/return-results/pom.xml
@@ -38,6 +38,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/rolling-aggregation/pom.xml
+++ b/jet/rolling-aggregation/pom.xml
@@ -44,6 +44,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/session-windows/pom.xml
+++ b/jet/session-windows/pom.xml
@@ -30,6 +30,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/sliding-windows/pom.xml
+++ b/jet/sliding-windows/pom.xml
@@ -39,6 +39,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/sockets/pom.xml
+++ b/jet/sockets/pom.xml
@@ -39,6 +39,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/source-sink-builder/pom.xml
+++ b/jet/source-sink-builder/pom.xml
@@ -55,6 +55,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/tf-idf/pom.xml
+++ b/jet/tf-idf/pom.xml
@@ -38,6 +38,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/trade-source/pom.xml
+++ b/jet/trade-source/pom.xml
@@ -44,6 +44,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/wordcount-compute-isolation/pom.xml
+++ b/jet/wordcount-compute-isolation/pom.xml
@@ -83,6 +83,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jet/wordcount/pom.xml
+++ b/jet/wordcount/pom.xml
@@ -48,6 +48,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/jmx/pom.xml
+++ b/jmx/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/json/jsongrid/jsongrid-client-java/pom.xml
+++ b/json/jsongrid/jsongrid-client-java/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>

--- a/json/jsongrid/jsongrid-database-tester/pom.xml
+++ b/json/jsongrid/jsongrid-database-tester/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/json/jsongrid/jsongrid-database/pom.xml
+++ b/json/jsongrid/jsongrid-database/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/json/jsongrid/jsongrid-server/pom.xml
+++ b/json/jsongrid/jsongrid-server/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/json/jsongrid/pom.xml
+++ b/json/jsongrid/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/json/pom.xml
+++ b/json/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/learning-basics/configure-datastructures-at-runtime/pom.xml
+++ b/learning-basics/configure-datastructures-at-runtime/pom.xml
@@ -21,7 +21,6 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <profiles>

--- a/learning-basics/configure-logging/pom.xml
+++ b/learning-basics/configure-logging/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <log4j.version>1.2.17</log4j.version>
         <slf4j.api.version>1.6.6</slf4j.api.version>

--- a/learning-basics/configure-programmatic/pom.xml
+++ b/learning-basics/configure-programmatic/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/configure-xml/pom.xml
+++ b/learning-basics/configure-xml/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/configure-yaml/pom.xml
+++ b/learning-basics/configure-yaml/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/destroying-instances/pom.xml
+++ b/learning-basics/destroying-instances/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/loading-instances/pom.xml
+++ b/learning-basics/loading-instances/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/multiple-hazelcast-instances/pom.xml
+++ b/learning-basics/multiple-hazelcast-instances/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/pom.xml
+++ b/learning-basics/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/learning-basics/unique-names/pom.xml
+++ b/learning-basics/unique-names/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/learning-basics/wildcard-configuration/pom.xml
+++ b/learning-basics/wildcard-configuration/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/monitoring/cluster-safety/pom.xml
+++ b/monitoring/cluster-safety/pom.xml
@@ -18,6 +18,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/monitoring/pom.xml
+++ b/monitoring/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/near-cache/fraud-detection/fraud-detection-client-common/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-common/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>

--- a/near-cache/fraud-detection/fraud-detection-client-with/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-with/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencies>
         <dependency>

--- a/near-cache/fraud-detection/fraud-detection-client-without/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-without/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/near-cache/fraud-detection/fraud-detection-common/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-common/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/near-cache/fraud-detection/fraud-detection-server/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-server/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/near-cache/fraud-detection/pom.xml
+++ b/near-cache/fraud-detection/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/near-cache/pom.xml
+++ b/near-cache/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/network-configuration/advanced-network-configuration/pom.xml
+++ b/network-configuration/advanced-network-configuration/pom.xml
@@ -19,7 +19,6 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
 </project>

--- a/network-configuration/aws/pom.xml
+++ b/network-configuration/aws/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/firewall/pom.xml
+++ b/network-configuration/firewall/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/groups/group1/pom.xml
+++ b/network-configuration/groups/group1/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/groups/group2/pom.xml
+++ b/network-configuration/groups/group2/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/groups/pom.xml
+++ b/network-configuration/groups/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/network-configuration/jclouds-partitiongroup/pom.xml
+++ b/network-configuration/jclouds-partitiongroup/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jclouds.version>1.9.1</jclouds.version>
         <hazelcast.version>3.12.6</hazelcast.version>

--- a/network-configuration/jclouds/pom.xml
+++ b/network-configuration/jclouds/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jclouds.version>1.9.1</jclouds.version>
         <hazelcast.version>3.12.6</hazelcast.version>

--- a/network-configuration/multicast-plugin/pom.xml
+++ b/network-configuration/multicast-plugin/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/multicast/pom.xml
+++ b/network-configuration/multicast/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/partitiongroup/pom.xml
+++ b/network-configuration/partitiongroup/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/pom.xml
+++ b/network-configuration/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/network-configuration/port/pom.xml
+++ b/network-configuration/port/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/network-configuration/tcpip/pom.xml
+++ b/network-configuration/tcpip/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/org-website-samples/pom.xml
+++ b/org-website-samples/pom.xml
@@ -17,7 +17,6 @@
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
         <jsr107.api.version>1.1.1</jsr107.api.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/osgi/pom.xml
+++ b/osgi/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <osgi.version>6.0.0</osgi.version>
         <felix.version>5.4.0</felix.version>

--- a/partition/pom.xml
+++ b/partition/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/querying/pom.xml
+++ b/querying/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/querying/project-key/pom.xml
+++ b/querying/project-key/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <hazelcast.version>3.9</hazelcast.version>
         <hazelcast-jet.version>3.2.2</hazelcast-jet.version>

--- a/replicated-map/basics/pom.xml
+++ b/replicated-map/basics/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/replicated-map/entry-listener/pom.xml
+++ b/replicated-map/entry-listener/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/replicated-map/in-memory-format/pom.xml
+++ b/replicated-map/in-memory-format/pom.xml
@@ -17,6 +17,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/replicated-map/pom.xml
+++ b/replicated-map/pom.xml
@@ -21,7 +21,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/serialization/benchmarks/pom.xml
+++ b/serialization/benchmarks/pom.xml
@@ -22,7 +22,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <grpc.version>1.47.0</grpc.version>
         <javax.annotation-api.version>1.3.2</javax.annotation-api.version>
@@ -32,7 +31,6 @@
         <maven-assembly-plugin.version>3.3.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <protobuf.version>3.21.7</protobuf.version>
         <protobuf-maven-plugin.version>0.6.1</protobuf-maven-plugin.version>
         <slf4j.version>1.7.30</slf4j.version>

--- a/serialization/bytearray-serializer/pom.xml
+++ b/serialization/bytearray-serializer/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/compact/pom.xml
+++ b/serialization/compact/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/data-serializable/pom.xml
+++ b/serialization/data-serializable/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/externalizable/pom.xml
+++ b/serialization/externalizable/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/global-serializer/pom.xml
+++ b/serialization/global-serializer/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/hazelcast-airlines/grid-node/pom.xml
+++ b/serialization/hazelcast-airlines/grid-node/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/serialization/hazelcast-airlines/pom.xml
+++ b/serialization/hazelcast-airlines/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <hazelcast.version>5.5.0</hazelcast.version>
         <kryo.version>4.0.0</kryo.version>

--- a/serialization/hazelcast-airlines/the-code/pom.xml
+++ b/serialization/hazelcast-airlines/the-code/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/serialization/hazelcast-instance-aware/pom.xml
+++ b/serialization/hazelcast-instance-aware/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/identified-data-serializable/pom.xml
+++ b/serialization/identified-data-serializable/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/kryo-serializer/pom.xml
+++ b/serialization/kryo-serializer/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/serialization/managed-context/pom.xml
+++ b/serialization/managed-context/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/murmur3/pom.xml
+++ b/serialization/murmur3/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/serialization/pom.xml
+++ b/serialization/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/serialization/portable/pom.xml
+++ b/serialization/portable/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/protobuf-serializer/pom.xml
+++ b/serialization/protobuf-serializer/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/serialization/serializable/pom.xml
+++ b/serialization/serializable/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/stream-serializer/pom.xml
+++ b/serialization/stream-serializer/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/serialization/user-context/pom.xml
+++ b/serialization/user-context/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/spi/discovery/pom.xml
+++ b/spi/discovery/pom.xml
@@ -18,6 +18,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/spi/pom.xml
+++ b/spi/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spi/split-brain/pom.xml
+++ b/spi/split-brain/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spi/tenant-control/pom.xml
+++ b/spi/tenant-control/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/pom.xml
+++ b/spring/pom.xml
@@ -45,7 +45,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.boot.version>3.4.2</spring.boot.version>
     </properties>

--- a/spring/spring-boot-caching-hazelcast-cache-manager/pom.xml
+++ b/spring/spring-boot-caching-hazelcast-cache-manager/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>spring-boot-caching-hazelcast-cache-manager</artifactId>
-    <version>0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Spring Boot Caching with Hazelcast Cache Manager</name>
 

--- a/spring/spring-boot-caching-jcache/pom.xml
+++ b/spring/spring-boot-caching-jcache/pom.xml
@@ -9,7 +9,6 @@
     </parent>
 
     <artifactId>spring-boot-caching-jcache</artifactId>
-    <version>0.1-SNAPSHOT</version>
 
     <name>Caching with Spring Boot, JCache and Hazelcast</name>
 

--- a/spring/spring-configuration/pom.xml
+++ b/spring/spring-configuration/pom.xml
@@ -8,7 +8,6 @@
 
     <artifactId>HazelcastSpring</artifactId>
     <groupId>HazelcastSpring</groupId>
-    <version>0.1-SNAPSHOT</version>
     <name>Hazelcast Spring Configuration Example</name>
     <url>http://hazelcast.org/</url>
 
@@ -21,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.version>5.2.24.RELEASE</spring.version>
     </properties>

--- a/spring/spring-data-hazelcast-chemistry-sample/client/pom.xml
+++ b/spring/spring-data-hazelcast-chemistry-sample/client/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-hazelcast-chemistry-sample/common/pom.xml
+++ b/spring/spring-data-hazelcast-chemistry-sample/common/pom.xml
@@ -15,6 +15,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/spring/spring-data-hazelcast-chemistry-sample/pom.xml
+++ b/spring/spring-data-hazelcast-chemistry-sample/pom.xml
@@ -10,7 +10,6 @@
 
     <groupId>com.hazelcast.samples.spring.data.chemistry</groupId>
     <artifactId>spring-data-hazelcast-chemistry-sample</artifactId>
-    <version>0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring Data Hazelcast Chemistry Parent (${project.packaging})</name>
@@ -19,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-data-hazelcast.version>2.4.0</spring-data-hazelcast.version>
         <spring-shell.version>3.4.0</spring-shell.version>

--- a/spring/spring-data-hazelcast-chemistry-sample/server/pom.xml
+++ b/spring/spring-data-hazelcast-chemistry-sample/server/pom.xml
@@ -16,7 +16,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-domain/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-domain/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-hz-main/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-hz-main/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-jpa-repository/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-jpa-repository/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-jpa-service/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-jpa-service/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-kv-repository/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-kv-repository/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-kv-service/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-kv-service/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/after-main/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/after-main/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/after/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/after/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/spring/spring-data-jpa-hazelcast-migration/before/before-domain/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/before/before-domain/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/before/before-jpa-repository/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/before/before-jpa-repository/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/before/before-jpa-service/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/before/before-jpa-service/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/before/before-main/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/before/before-main/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/before/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/before/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/spring/spring-data-jpa-hazelcast-migration/database/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/database/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/spring-data-jpa-hazelcast-migration/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/pom.xml
@@ -18,7 +18,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring-data-hazelcast.version>2.1</spring-data-hazelcast.version>
         <spring-shell.version>1.2.0.RELEASE</spring-shell.version>

--- a/spring/spring-data-jpa-hazelcast-migration/shared/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/shared/pom.xml
@@ -17,7 +17,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/spring/springaware-annotation/pom.xml
+++ b/spring/springaware-annotation/pom.xml
@@ -15,7 +15,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <spring.version>5.2.24.RELEASE</spring.version>
     </properties>

--- a/sql/compact/pom.xml
+++ b/sql/compact/pom.xml
@@ -20,6 +20,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/sql/hazdb/pom.xml
+++ b/sql/hazdb/pom.xml
@@ -26,7 +26,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <build.timestamp>${maven.build.timestamp}</build.timestamp>
         <docker.image.prefix>hazdb</docker.image.prefix>

--- a/sql/pom.xml
+++ b/sql/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/transactions/pom.xml
+++ b/transactions/pom.xml
@@ -20,7 +20,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <modules>

--- a/transactions/transaction-basics/pom.xml
+++ b/transactions/transaction-basics/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/transactions/transactional-task/pom.xml
+++ b/transactions/transactional-task/pom.xml
@@ -19,6 +19,5 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 </project>

--- a/transactions/xa-transactions/pom.xml
+++ b/transactions/xa-transactions/pom.xml
@@ -19,7 +19,6 @@
     <properties>
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.parent.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <atomikos-version>3.9.3</atomikos-version>
     </properties>

--- a/variable-replacers/pom.xml
+++ b/variable-replacers/pom.xml
@@ -15,7 +15,6 @@
 
     <properties>
         <main.basedir>${project.parent.basedir}</main.basedir>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
The parent declares:
- `project.build.sourceEncoding`
- Java version
- project version (`0.1-SNAPSHOT`)

As such we don't need to explicitly redeclare this in children `POM`s.