### PR TITLE
Rename docs component to templates

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
-name: hazelcast
-version: 6.0-snapshot
+name: templates
+version: v0.1

--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,2 +1,2 @@
 name: templates
-version: v0.1
+version: ~


### PR DESCRIPTION
How it should be used: `include::templates:ROOT:example$/...`
Example: https://github.com/hazelcast/hz-docs/pull/1573/files#diff-e04cd751764133e07ed15bc37ced53d7875e23f845e42dac8dcef6d778a763c7R150
Result: https://deploy-preview-1573--hardcore-allen-f5257d.netlify.app/hazelcast/6.0-snapshot/what-is-hazelcast.html