### PR TITLE
Remove Docker compose obselete `version` attribute

### DIFF
--- a/jet/kafka/hazelcast-compose.yml
+++ b/jet/kafka/hazelcast-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   hazelcast:
     image: hazelcast/hazelcast:5.1.1


### PR DESCRIPTION
Addresses warning:
```
attribute `version` is obsolete
```

https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-top-level-element-obsolete