### PR TITLE
Set `spring-boot-maven-plugin` version

### DIFF
--- a/enterprise/pcf-tls-integration/pom.xml
+++ b/enterprise/pcf-tls-integration/pom.xml
@@ -48,7 +48,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hazelcast-integration/aws-ecs/pom.xml
+++ b/hazelcast-integration/aws-ecs/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.1.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hazelcast-integration/eureka/springboot-embedded/hazelcast-metadata/pom.xml
+++ b/hazelcast-integration/eureka/springboot-embedded/hazelcast-metadata/pom.xml
@@ -62,7 +62,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.1.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hazelcast-integration/eureka/springboot-embedded/hazelcast-only/pom.xml
+++ b/hazelcast-integration/eureka/springboot-embedded/hazelcast-only/pom.xml
@@ -51,7 +51,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.1.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hazelcast-integration/eureka/springboot-embedded/hazelcast-separate-client/pom.xml
+++ b/hazelcast-integration/eureka/springboot-embedded/hazelcast-separate-client/pom.xml
@@ -62,7 +62,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.0.1.RELEASE</version>
                 <executions>
                     <execution>
                         <goals>

--- a/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
+++ b/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/pom.xml
@@ -75,15 +75,6 @@
     </dependencyManagement>
 
     <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring.boot.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <!-- Define docker plugin for all modules to use, skip per module when not needed -->
         <plugins>
             <plugin>

--- a/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
+++ b/hazelcast-integration/openshift/client-apps/ocp-demo-frontend/pom.xml
@@ -75,7 +75,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/jcache-1.1/times-table/jcache-server/pom.xml
+++ b/jcache-1.1/times-table/jcache-server/pom.xml
@@ -41,7 +41,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/jcache-1.1/times-table/jcache-spring/pom.xml
+++ b/jcache-1.1/times-table/jcache-spring/pom.xml
@@ -50,7 +50,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/json/jsongrid/jsongrid-client-java/pom.xml
+++ b/json/jsongrid/jsongrid-client-java/pom.xml
@@ -27,7 +27,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/json/jsongrid/jsongrid-database-tester/pom.xml
+++ b/json/jsongrid/jsongrid-database-tester/pom.xml
@@ -34,7 +34,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/json/jsongrid/jsongrid-database/pom.xml
+++ b/json/jsongrid/jsongrid-database/pom.xml
@@ -34,7 +34,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/json/jsongrid/jsongrid-server/pom.xml
+++ b/json/jsongrid/jsongrid-server/pom.xml
@@ -34,7 +34,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/near-cache/fraud-detection/fraud-detection-client-with/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-with/pom.xml
@@ -32,7 +32,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/near-cache/fraud-detection/fraud-detection-client-without/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-client-without/pom.xml
@@ -33,7 +33,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/near-cache/fraud-detection/fraud-detection-server/pom.xml
+++ b/near-cache/fraud-detection/fraud-detection-server/pom.xml
@@ -33,7 +33,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,11 @@
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                    <version>${spring.boot.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/querying/project-key/pom.xml
+++ b/querying/project-key/pom.xml
@@ -81,7 +81,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/serialization/hazelcast-airlines/grid-node/pom.xml
+++ b/serialization/hazelcast-airlines/grid-node/pom.xml
@@ -35,7 +35,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/spring/spring-data-hazelcast-chemistry-sample/pom.xml
+++ b/spring/spring-data-hazelcast-chemistry-sample/pom.xml
@@ -29,18 +29,6 @@
         <module>client</module>
     </modules>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring.boot.version}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
-
     <dependencyManagement>
         <dependencies>
             <!-- adding SpringBoot BOM -->

--- a/spring/spring-data-jpa-hazelcast-migration/database/pom.xml
+++ b/spring/spring-data-jpa-hazelcast-migration/database/pom.xml
@@ -42,7 +42,6 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>${spring.boot.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/sql/hazdb/pom.xml
+++ b/sql/hazdb/pom.xml
@@ -127,7 +127,6 @@
                 <plugin>
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-maven-plugin</artifactId>
-                    <version>${spring.boot.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION
Fix warning:
```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for com.hazelcast.samples:spring-boot-caching-hazelcast-cache-manager:jar:0.1-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.springframework.boot:spring-boot-maven-plugin is missing. @ line 34, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```