### PR TITLE
Allow Dependabot to trigger PR Builder

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -22,7 +22,7 @@ jobs:
     needs: check_for_membership
     steps:
       - name: Detect untrusted community PR
-        if: ${{ needs.check_for_membership.outputs.check-result == 'false' }}
+        if: ${{ needs.check_for_membership.outputs.check-result == 'false' && github.actor != 'dependabot[bot]' }}
         run: |
           echo "::error::ERROR: Untrusted external PR. Must be reviewed and executed by Hazelcast" 1>&2;
           exit 1


### PR DESCRIPTION
[Dependabot PRs are blocked](https://github.com/hazelcast/hazelcast-code-samples/pull/728) from PR builder execution, should be whitelisted.