### PR TITLE
Update Maven central URL

### DIFF
--- a/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/the-management-center/Dockerfile
+++ b/hazelcast-integration/kubernetes/samples/springboot-k8s-hello-world/the-management-center/Dockerfile
@@ -1,7 +1,7 @@
 FROM hazelcast/management-center:4.0.1
 
 RUN wget -O ${MC_HOME}/hazelcast-kubernetes.jar \
-          https://repo1.maven.org/maven2/com/hazelcast/hazelcast-kubernetes/2.0.1/hazelcast-kubernetes-2.0.1.jar
+          https://repo.maven.apache.org/maven2/com/hazelcast/hazelcast-kubernetes/2.0.1/hazelcast-kubernetes-2.0.1.jar
 
 ENV JAVA_OPTS='-Dhazelcast.mc.healthCheck.enable=true'
 ENV MC_CLASSPATH "${MC_HOME}/hazelcast-kubernetes.jar"


### PR DESCRIPTION
In https://issues.apache.org/jira/browse/MNG-5151 Maven updated the default URL from `repo1.maven.org/maven2` -> `repo.maven.apache.org/maven2`.

Updated references to suit.