### PR TITLE
Update PR builder membership test to use `triggering_actor` to make community PR execution easier

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -14,7 +14,7 @@ jobs:
         id: composite
         uses: hazelcast/hazelcast-tpm/membership@main
         with:
-          member-name: ${{ github.actor }}
+          member-name: ${{ github.triggering_actor }}
           token: ${{ secrets.GH_TOKEN }}
   pr-builder:
     runs-on: ubuntu-latest


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-cpp-client/pull/1442