### PR TITLE
Ensure `fail` option used with curl to catch errors

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Detect untrusted community PR
         if: ${{ needs.check_for_membership.outputs.check-result == 'false' && github.event.pull_request.user.login != 'dependabot[bot]' }}
         run: |
-          source /dev/stdin <<< "$(curl --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
+          source /dev/stdin <<< "$(curl --fail --silent https://raw.githubusercontent.com/hazelcast/github-actions-common-scripts/main/logging.functions.sh)"
           echoerr "Untrusted external PR. Must be reviewed and executed by Hazelcast"
           exit 1
       # Default GitHub runners have very little free disk space causing build failures


### PR DESCRIPTION
By default, curl returns a `0` exit code even in the case of 404 errors.

This means that errors like the one in https://github.com/hazelcast/hazelcast-mono/pull/7091 are tricky to spot. It would be better if we used the [`fail` option](https://curl.se/docs/manpage.html#--fail) to ensure the failure is visible.